### PR TITLE
Update to latest pin, numpy, and matplotlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,16 @@ The aim is to increase the reachability using this programming language without 
 
 The source code was developed on Ubuntu 22.04 with:
 
-1. Python 3.10
-2. [Pinocchio](https://stack-of-tasks.github.io/pinocchio/download.html#Install_1) 2.6.20
-3. Matplotlib 3.6.2
-4. Numpy 1.23.5
+1. Python 3.12
+2. [Pinocchio](https://github.com/stack-of-tasks/pinocchio) (`pin` on PyPI) 4.1.0
+3. Matplotlib 3.11.0
+4. Numpy 2.5.1
 
-Versions are recommended, but not strictly.
+Versions are recommended, but not strictly. Install them via:
+```sh
+pip install -r requirements.txt
+```
+
 Once installed these dependencies, clone the repo:
 ```sh
 git clone git@github.com:leggedrobotics-usp/impedance_control_benchmark.git

--- a/controllers/impedance_6dof.py
+++ b/controllers/impedance_6dof.py
@@ -11,6 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
+import atexit
 import pinocchio as pin
 import numpy as np
 import time as tm
@@ -33,6 +34,16 @@ viz = MeshcatVisualizer()
 
 robot.setVisualizer(viz)
 robot.initViewer(open=open_viewer)
+
+# meshcat-server keeps its scene tree across reconnects (even in a fresh/incognito
+# tab) and its subprocess is never torn down by MeshcatVisualizer/Visualizer.close()
+# (broken upstream: ViewerWindow has no close()), so leftover objects from a prior
+# run/REPL session can silently persist. Clear the scene on every startup, and kill
+# our own server subprocess when this interpreter actually exits (works with `-i`,
+# since it fires on REPL exit, not right after the script body finishes).
+viz.viewer.delete()
+atexit.register(lambda: viz.viewer.window.server_proc and viz.viewer.window.server_proc.terminate())
+
 robot.loadViewerModel()
 NQ, NV = robot.model.nq, robot.model.nv
 end_effector = robot.model.getFrameId("ee_link")

--- a/controllers/impedance_6dof.py
+++ b/controllers/impedance_6dof.py
@@ -12,6 +12,7 @@
 # GNU General Public License for more details.
 
 import atexit
+from pathlib import Path
 import pinocchio as pin
 import numpy as np
 import time as tm
@@ -22,6 +23,34 @@ from pinocchio.visualize import MeshcatVisualizer
 import example_robot_data
 
 
+def _patch_meshcat_viewer_bundle():
+    """Fix partial mesh rendering in the meshcat.js bundled with meshcat 0.3.2.
+
+    Its merge_geometries() flattens a multi-mesh Collada scene into one Mesh,
+    pushing each sub-mesh's material into a flat list. A sub-mesh with several
+    material primitives (all UR5 visual DAEs have these) contributes a *nested
+    array* to that list, and three.js silently skips geometry groups whose
+    material slot is an array — links lose their joint housings and render as
+    scattered fragments. Flatten to the first material so every group draws.
+    Patches the installed bundle in place; idempotent, and a no-op if the
+    bundle doesn't match (e.g. once meshcat ships a fixed viewer).
+    """
+    import meshcat
+
+    bundle = Path(meshcat.__file__).parent / "viewer" / "dist" / "main.min.js"
+    broken = "i.push(t.geometry),n.push(t.material)"
+    fixed = "i.push(t.geometry),n.push(Array.isArray(t.material)?t.material[0]:t.material)"
+    try:
+        src = bundle.read_text()
+        if broken in src:
+            bundle.write_text(src.replace(broken, fixed))
+    except OSError as exc:
+        print(f"warning: could not patch meshcat viewer bundle ({exc}); "
+              "robot meshes may render partially")
+
+
+_patch_meshcat_viewer_bundle()
+
 controller = 4  # Choose the impedance controller
 plotting = False  # dismiss plot if false
 savefile = False  # dismiss log save if false
@@ -30,13 +59,8 @@ open_viewer = (
 )
 
 robot = example_robot_data.load("ur5")
-# loadViewerModel() below always loads collision_model geometry (large capsule/
-# sphere primitives approximating each link) alongside the visual mesh, then
-# tries to hide it via a "visible=false" property on the group. That property
-# is correctly stored server-side but isn't reliably honored by the meshcat.js
-# client on (re)connect, so the collision shapes render as floating extra blobs
-# next to the real arm. Drop the collision model so there's nothing to load or
-# hide in the first place; nothing in this script uses collision geometry.
+# The demo doesn't use collision geometry; drop it so loadViewerModel() has
+# nothing extra to load and the viewer scene stays lean.
 robot.collision_model = None
 viz = MeshcatVisualizer()
 

--- a/controllers/impedance_6dof.py
+++ b/controllers/impedance_6dof.py
@@ -30,6 +30,14 @@ open_viewer = (
 )
 
 robot = example_robot_data.load("ur5")
+# loadViewerModel() below always loads collision_model geometry (large capsule/
+# sphere primitives approximating each link) alongside the visual mesh, then
+# tries to hide it via a "visible=false" property on the group. That property
+# is correctly stored server-side but isn't reliably honored by the meshcat.js
+# client on (re)connect, so the collision shapes render as floating extra blobs
+# next to the real arm. Drop the collision model so there's nothing to load or
+# hide in the first place; nothing in this script uses collision geometry.
+robot.collision_model = None
 viz = MeshcatVisualizer()
 
 robot.setVisualizer(viz)

--- a/docs/design/sim-framework/design.md
+++ b/docs/design/sim-framework/design.md
@@ -1,0 +1,261 @@
+# System Design Document — Experimental Simulation Package (`icbench`)
+
+Rev 1 — 2026-07-17. Satisfies [requirements.md](requirements.md); verified per
+[verification.md](verification.md); built per [plan.md](plan.md).
+
+## 1. Architecture Overview
+
+Two-engine split: **MuJoCo is the world** (truth: contacts, friction, actuator
+limits, sensors), **Pinocchio is the controller's model** (what the control law
+*believes*: M, nle, g, Jacobians). Both are built from one preprocessed URDF so
+the belief matches the truth exactly at first — later robustness studies
+(REQ-ANA-001) deliberately perturb the *controller side only*.
+
+```mermaid
+flowchart TB
+    subgraph experiments/
+        X[experiment script + _common.py args]
+    end
+    subgraph icbench
+        RN[runner.Experiment]
+        subgraph sim
+            W[world.World<br/>mjModel/mjData, remap]
+            SC[scene.py<br/>mjSpec builders]
+        end
+        subgraph control
+            CB[base.Controller ABC]
+            CM[ctrl_model.CtrlModel<br/>pinocchio]
+            IMP[impedance / joint_pd /<br/>computed_torque / admittance]
+        end
+        subgraph tasks
+            TB[base.Task ABC]
+            TS[free_space / wall_contact / surface_slide]
+        end
+        subgraph viz
+            VB[base.Viewer ABC]
+            VM[mujoco_viewer]
+            VMC[meshcat_viewer + meshcat_patch]
+        end
+        MD[models.py<br/>URDF preprocess, registry, joint map]
+        RC[recording.Recorder]
+        AN[analysis/ sweep, sysid]
+    end
+    X --> RN
+    RN --> W & CB & TB & VB
+    IMP -.implements.-> CB
+    TS -.implements.-> TB
+    VM & VMC -.implement.-> VB
+    IMP --> CM
+    MD --> W & CM & VMC
+    TB -->|build_scene| SC --> W
+    RN --> RC
+    AN --> RN
+```
+
+### 1.1 Key design decisions
+
+| ID | Decision | Rationale | Satisfies |
+|---|---|---|---|
+| DD-1 | Dual engine, single URDF, preprocessing in `models.py` | No model mismatch; MuJoCo can't read `package://` or DAE | REQ-MDL-002 |
+| DD-2 | **Gravity convention**: plant real, controllers output total torque (own g/nle comp via CtrlModel) | Legacy plant `aba(q,dq,tau+g)` hides compensation; copying it would make every MuJoCo result wrong | REQ-SIM-006, REQ-CTL-001 |
+| DD-3 | Canonical joint order = URDF/pinocchio order; World owns the mj↔canonical remap as *data* (index map from models.py) | One convention at every component boundary; ordering bugs become impossible to write silently | REQ-MDL-003, REQ-SIM-002 |
+| DD-4 | Typed `Reference` covering pose/twist/accel, joint targets, wrench target — from day one | Contact tasks (wrench) and joint controllers (q_des) otherwise force interface rework in Phases 4/6 | REQ-TSK-001, REQ-CTL-006 |
+| DD-5 | LogSchema (fixed channel names/units) defined in runner at Phase 2; Task.metrics and Recorder consume it | Single contract; no silent field drift | REQ-EXP-001, REQ-REC-001 |
+| DD-6 | Config dataclasses per controller/task, dict-constructible | YAML sweep layer maps dicts→dataclasses with zero controller changes | REQ-CTL-007, REQ-ANA-001 |
+| DD-7 | MuJoCo viewer authoritative; meshcat best-effort mirror | Physics scene truth vs pretty visuals; bounded maintenance | REQ-VIZ-001/002 |
+| DD-8 | Tasks own all scene geometry (incl. floor) | Free-fall tests and free-space parity need an empty world | REQ-TSK-001 |
+| DD-9 | Effort limits on actuators by default, opt-out flag | Realistic torque saturation for honest comparisons | REQ-MDL-005 |
+
+## 2. Data Design
+
+### 2.1 Core types (canonical order everywhere)
+
+```python
+@dataclass
+class State:
+    q: np.ndarray          # (nv,) rad — canonical order
+    dq: np.ndarray         # (nv,) rad/s
+    tau_applied: np.ndarray# (nv,) N·m — last commanded torque
+    t: float               # s
+
+@dataclass
+class Reference:
+    pose: pin.SE3 | None          # task-space target
+    twist: np.ndarray | None      # (6,) LOCAL_WORLD_ALIGNED
+    accel: np.ndarray | None      # (6,)
+    q_des: np.ndarray | None      # joint-space targets (joint controllers)
+    dq_des: np.ndarray | None
+    ddq_des: np.ndarray | None
+    wrench_des: np.ndarray | None # (6,) world-aligned, robot-on-env positive
+```
+
+### 2.2 LogSchema channels (fixed at Phase 2; append-only afterwards)
+
+| Channel | Shape/step | Unit | Source |
+|---|---|---|---|
+| `t` | () | s | runner |
+| `q`, `dq`, `tau` | (nv,) | rad, rad/s, N·m | World / controller |
+| `ee_pos`, `ee_rpy` | (3,) | m, rad | CtrlModel FK |
+| `ee_vel` | (6,) | m/s, rad/s | J·dq |
+| `ee_wrench_ft` | (6,) | N, N·m | World F/T sensor (world-aligned) |
+| `ee_wrench_contact` | (6,) | N, N·m | Σ mj_contactForce (ground truth) |
+| `ref_*` | mirrors Reference fields | — | Task |
+
+New channels may be appended; existing names/units never change (DD-5).
+
+### 2.3 Run artifact (Recorder, REQ-REC-001)
+
+```
+data/runs/<UTC-timestamp>_<experiment>/
+  config.json      # full config dataclasses + seed + git SHA
+  timeseries.npz   # LogSchema arrays
+  metrics.json     # Task.metrics output
+  *.png            # the same plots the interactive run shows
+```
+
+## 3. Component Design
+
+### 3.1 `models.py`
+
+- `load_robot(name: str) -> RobotBundle`
+- Steps: locate URDF+meshes via example-robot-data → preprocess to a temp URDF
+  (rewrite `package://example-robot-data/` → absolute share path; strip `<visual>`
+  if MuJoCo's `discardvisual` proves insufficient in the Phase 0 spike) → build
+  pin `RobotWrapper` (with DAE visual model for meshcat) → build `mjSpec` robot
+  (compiler: `balanceinertia=false`) → derive joint index map by *name* matching.
+- `RobotBundle`: pin wrapper, preprocessed URDF path, mesh dir, joint map,
+  `q_pin_from_mj / v_pin_from_mj / v_mj_from_pin` converters, effort limits.
+- Guards (REQ-MDL-004): raise on unmatched joint names, `pin.nq != pin.nv`
+  (continuous joints — unsupported until converters extended), nonzero URDF
+  `<dynamics>` damping/friction.
+- Errors: fail at load time with the offending joint/mesh named.
+
+### 3.2 `sim/scene.py`
+
+- `attach_actuators(spec, bundle, use_effort_limits=True)` — one `<motor>` per
+  joint, `forcerange=±effort` (DD-9).
+- `add_ee_sensor(spec, site_name="ee")` — site at ee frame + force/torque sensor.
+- `add_floor(spec)`, `add_wall(spec, pose, size, friction)` — called only from
+  `Task.build_scene` (DD-8).
+
+### 3.3 `sim/world.py`
+
+- Owns `mjModel/mjData`, the remap, and stepping:
+  `step(tau_canonical, n_substeps)` → map to mj order → set `ctrl` → `mj_step`×n.
+- `state() -> State` (canonical), `ee_wrench()` (sensor → rotate by site `xmat`
+  into world axes → sign per Conventions), `contacts()` (raw, X-normal frame
+  documented at the accessor), `apply_external_wrench(frame, wrench)`
+  (`xfrc_applied`, cleared each step unless re-applied — REQ-SIM-005).
+- No gravity logic anywhere (DD-2): World never adds/removes compensation.
+
+### 3.4 `control/ctrl_model.py`
+
+- Pinocchio wrapper: `M(q)`, `nle(q,dq)`, `g(q)`, `coriolis(q,dq)`
+  (`computeCoriolisMatrix`), `frame_jacobian(q, frame)` / `frame_jacobian_dot`
+  (LOCAL_WORLD_ALIGNED), `fk(q, frame) -> SE3`.
+- Stateless per call; canonical order in/out. Later: constructor takes optional
+  parameter perturbations (payload error etc.) for robustness studies.
+
+### 3.5 `control/impedance.py` (and zoo)
+
+- `TaskSpaceImpedance(ctrl_model, config)` with `variant ∈ {2,3,4}`; reformulated
+  per DD-2: e.g. variant 4 becomes `tau = Jᵀ(Kd·x_err + Dd·v_err) + g(q)`
+  (legacy relied on the plant's hidden `+g`). Variants 2/3 replace the legacy
+  broadcast-bug term with `(C(q,dq) − M·J⁺·dJ)·J⁺·v_des` using the Coriolis
+  *matrix*; all task-space inverses via damped least squares
+  (`J⁺ = Jᵀ(JJᵀ+λ²I)⁻¹`) with manipulability-based λ scheduling (REQ-CTL-005).
+- Derivations recorded in findings.md (REQ-CTL-003 Ver=A part).
+- `control_rate_hz` declared per instance (variant 2 → 1000).
+- Zoo (Phase 6): `JointPD`, `ComputedTorque`; `Admittance(inner: Controller, ...)`
+  — outer wrench→motion loop, 1st-order low-pass on `ee_wrench_ft` (cutoff
+  config, default well below inner-loop bandwidth), composes inner tracking
+  controller at 1 kHz (REQ-CTL-006).
+
+### 3.6 `tasks/`
+
+- `Task.build_scene(spec)`: all env geometry. `reference(t) -> Reference`.
+  `metrics(log) -> dict`.
+- `FreeSpace`: regulation / sinusoidal modes + optional sine ee-force disturbance
+  (via World primitive) — parity with legacy `fe_amp·sin(fe_angf·t)` behavior.
+- `WallContact`: phase machine (approach → press); `wrench_des` ramps to target;
+  metrics from `ee_wrench_contact`: steady-state error, overshoot, settling time.
+- `SurfaceSlide`: path + constant normal force; force RMSE metric.
+
+### 3.7 `viz/`
+
+- `MujocoViewer`: `mujoco.viewer.launch_passive`; syncs at wall-clock rate,
+  drops frames rather than slowing physics.
+- `MeshcatViewer`: pin `MeshcatVisualizer` (DAE visuals) driven by canonical q;
+  scene props mirrored from task metadata (wall → box) best-effort (DD-7).
+  Imports `meshcat_patch.py` — the merge_geometries bundle patch, single source,
+  loud warning when bundle matches neither pattern (REQ-VIZ-004); the legacy
+  script imports the same module.
+
+### 3.8 `runner.py`
+
+```
+Experiment(bundle, task, controller, viewer, dt_ctrl=None).run(duration)
+  dt_ctrl = controller.control_rate default; n_substeps = dt_ctrl/dt_phys (int, validated)
+  loop: state ← World.state(); ref ← task.reference(t)
+        tau ← controller.compute(state, ref, t, dt_ctrl)
+        World.step(tau, n_substeps); viewer.sync(state); log.append(...)
+  return log (LogSchema), task.metrics(log)
+```
+
+Owns LogSchema assembly (DD-5) and the seed (`np.random.default_rng(seed)` passed
+to any stochastic component; REQ-SIM-007).
+
+### 3.9 `recording.py`, `analysis/`
+
+- `Recorder.save(run_dir_name, config, log, metrics, figs)` per §2.3.
+- `analysis/sweep.py`: YAML → list of config dicts → dataclasses (DD-6) →
+  `multiprocessing` pool of headless runs → `metrics.parquet` + markdown report.
+- `analysis/sysid/payload_estimation.py`: regressor least-squares / RLS on
+  (q, dq, ddq_est, tau) with known-model terms from CtrlModel; ground truth from
+  the sweep payload machinery; reports estimate error + convergence time.
+
+## 4. Interface Control (cross-cutting contracts)
+
+| Contract | Definition | Enforced by |
+|---|---|---|
+| Joint order | canonical = URDF/pinocchio; map is data | TC-MDL-002 |
+| Frames | ee task quantities LOCAL_WORLD_ALIGNED; wrenches world-aligned | TC-SIM-003 |
+| Wrench sign | robot-on-environment positive | TC-SIM-003 |
+| Contact frame | mj X-axis = normal; documented at accessor | code review (I) |
+| Gravity | plant real; controllers self-compensate | TC-CTL-001, TC-SYS-001 |
+| LogSchema | names/units fixed, append-only | TC-EXP-001 |
+| Orientation error | `rpy(R_des·Rᵀ)` (documented limitation) | findings.md note |
+
+## 5. Dynamic View — control loop with contact
+
+```mermaid
+sequenceDiagram
+    participant T as Task
+    participant R as Runner
+    participant C as Controller
+    participant W as World (MuJoCo)
+    participant V as Viewer
+    loop every dt_ctrl
+        R->>W: state()
+        R->>T: reference(t)
+        R->>C: compute(state, ref, t, dt)
+        Note over C: M,nle,J from CtrlModel (pin)<br/>+ own gravity comp (DD-2)
+        C-->>R: tau (total, canonical)
+        R->>W: step(tau, n_substeps)
+        Note over W: remap → ctrl, mj_step ×n<br/>contacts, F/T sensor
+        R->>V: sync(state)
+        R->>R: log.append(channels)
+    end
+    R->>T: metrics(log)
+```
+
+## 6. Risks & Open Items
+
+| ID | Risk / open item | Mitigation / resolution point |
+|---|---|---|
+| R-1 | mjSpec URDF parsing quirks in mujoco 3.10 (compiler options exposure, visual handling) | Phase 0 spike; fallback: one-time MJCF export + committed template |
+| R-2 | UR5 URDF inertias violate triangle inequality → compile failure with `balanceinertia=false` | Spike; if so, minimally repair inertias in preprocessing and document (A-1) |
+| R-3 | Stiff wall contact + 1 kHz ZOH torque chatter | Tune solref/solimp per task; document in findings.md |
+| R-4 | Meshcat mirror drifting from MuJoCo scene | Accepted (DD-7); MuJoCo viewer is authority |
+| R-5 | EGL headless unavailable on some setup | Phase 0 spike verifies; sweeps need no rendering unless videos requested |
+| R-6 | Legacy parity harness dt/integrator sensitivity | Parity test replicates legacy integrator exactly (Euler, legacy dt), not MuJoCo |

--- a/docs/design/sim-framework/execution/index.md
+++ b/docs/design/sim-framework/execution/index.md
@@ -1,0 +1,99 @@
+# Execution Work Packages — Dispatch Index
+
+Rev 1 — 2026-07-17. Fifth document of the set (requirements → design →
+verification → plan → **execution**). Each work package (WP) is a self-contained
+brief executable by an agent with **zero conversation context** (Sonnet-class).
+
+## Dispatch protocol
+
+To dispatch a WP to a subagent, give it exactly:
+
+1. The **Common Briefing** below (paste verbatim),
+2. The WP section from the phase file (e.g. `phase-1.md` § WP-03),
+3. Nothing else. The WP lists every file the agent must read.
+
+Rules for the dispatcher:
+- Respect `Depends on:` — never dispatch a WP before its dependencies are merged.
+- WPs within a phase marked `[parallel-ok]` may run concurrently in separate
+  worktrees; all others are sequential.
+- After each WP: review the diff, run the acceptance commands yourself, then merge.
+
+## Common Briefing (paste into every subagent prompt)
+
+```
+You are implementing one work package of the `icbench` experimental robot-arm
+simulation package inside the repo at ~/ai/test/impedance_control_benchmark.
+
+Environment:
+- Python: ./.venv/bin/python   Tests: ./.venv/bin/pytest tests/ -q
+- All deps are pip-installed in .venv; do not install anything not listed in
+  your work package.
+
+Project conventions (violations are bugs):
+- SI units (m, s, rad, N, N·m). Canonical joint order = URDF/pinocchio order;
+  the MuJoCo<->canonical index map is DATA (built in icbench/models.py), never
+  assumed identity. World owns the remap; controllers/viewers only ever see
+  canonical order.
+- Task-space quantities: pinocchio LOCAL_WORLD_ALIGNED frame. Wrenches:
+  world-aligned axes, robot-on-environment positive.
+- GRAVITY CONVENTION: the plant is real (MuJoCo applies gravity; no hidden
+  compensation anywhere in World). Every controller returns TOTAL torque
+  including its own gravity/nle compensation. The legacy script
+  controllers/impedance_6dof.py line 291 uses aba(q,dq,tau+g) — a hidden
+  compensation you must NOT replicate in the package.
+- Config: every controller/task takes a @dataclass config constructible from a
+  plain dict.
+- Seeds: any randomness uses a fixed, recorded seed.
+
+Hard rules:
+- NEVER modify controllers/*.py (legacy demos) unless the WP explicitly says so.
+- NEVER modify files outside the WP's "Deliverables" list.
+- Write tests FIRST where the WP specifies tests; run the full suite before
+  finishing; everything green.
+- Commit style: conventional commits (feat:/test:/docs:), one commit per WP
+  unless the WP says otherwise. Do not push.
+- If you hit a contradiction between your WP and the code you find, STOP and
+  report it instead of improvising.
+
+Reference docs in docs/design/sim-framework/ (read only the sections your WP
+cites): requirements.md (REQ-IDs), design.md (DD-IDs, interfaces), verification.md
+(TC-IDs = your acceptance tests), plan.md (context).
+```
+
+## WP index and requirement mapping
+
+| WP | Phase file | Title | Implements | Acceptance | Depends on | Parallel |
+|---|---|---|---|---|---|---|
+| WP-01 | phase-0.md | Scaffold, deps, smoke test | REQ-NFR-004/005 (part) | TC (smoke) | — | no |
+| WP-02 | phase-0.md | Spike: URDF→MuJoCo, EGL | resolves R-1/R-2/R-5 | findings.md entries | WP-01 | no |
+| WP-03 | phase-1.md | models.py: preprocess, registry, joint map | REQ-MDL-001..004 | TC-MDL-001..003 | WP-02 | no |
+| WP-04 | phase-1.md | scene.py: actuators, ee sensor | REQ-MDL-005 | TC-MDL-004 | WP-03 | yes |
+| WP-05 | phase-1.md | types.py + world.py: World core | REQ-SIM-001..003/005/006 | TC-SIM-001..004 | WP-03, WP-04 | no |
+| WP-06 | phase-1.md | Cross-engine anchor tests | REQ-NFR-001 | TC-CE-001..004 | WP-05 | no |
+| WP-07 | phase-2.md | ctrl_model.py | REQ-CTL-002 | TC-CTL-002 | WP-06 | yes |
+| WP-08 | phase-2.md | Controller ABC + configs | REQ-CTL-001/007 | TC-CTL-007 | WP-06 | yes |
+| WP-09 | phase-2.md | Impedance (reformulated) + damped pinv | REQ-CTL-003/004/005 | TC-CTL-003/005/006 | WP-07, WP-08 | no |
+| WP-10 | phase-2.md | Legacy closed-loop parity test | REQ-CTL-003, REQ-NFR-006 | TC-CTL-004 | WP-09 | no |
+| WP-11 | phase-2.md | Task ABC + free_space | REQ-TSK-001/002 | (via WP-12 TCs) | WP-08 | yes |
+| WP-12 | phase-2.md | runner.py + LogSchema + determinism | REQ-EXP-001, REQ-SIM-007, REQ-NFR-003 | TC-EXP-001, TC-SIM-005, TC-SYS-001/002, TC-CTL-001 | WP-09, WP-11 | no |
+| WP-13 | phase-2.md | experiments/_common + free-space script + README | REQ-EXP-002/003, REQ-NFR-002 | TC-VAL-002, inspection | WP-12 | no |
+| WP-14 | phase-3.md | MuJoCo viewer | REQ-VIZ-001/003 | TC-VIZ-001/004 | WP-12 | yes |
+| WP-15 | phase-3.md | meshcat_patch module + meshcat viewer | REQ-VIZ-002/004 | TC-VIZ-002/003 | WP-12 | yes |
+| WP-16 | phase-4.md | Wall scene + wall_contact task + experiment | REQ-TSK-003, REQ-SIM-004 | TC-SYS-003 | WP-13 | no |
+| WP-17 | phase-4.md | surface_slide task | REQ-TSK-004 | TC-SYS-004 | WP-16 | yes |
+| WP-18 | phase-4.md | Validation: stiffness sweep + effort-limit study | REQ-MDL-005 (val) | TC-VAL-001/003 | WP-16 | yes |
+| WP-19 | phase-5.md | Recorder + gitignore | REQ-REC-001/002 | TC-REC-001 | WP-12 | no |
+| WP-20 | phase-6-8.md | joint_pd + computed_torque | REQ-CTL-006 (part) | zoo unit tests | WP-12 | yes |
+| WP-21 | phase-6-8.md | Admittance (outer/inner) | REQ-CTL-006 | TC-CTL-008 | WP-16, WP-20 | no |
+| WP-22 | phase-6-8.md | Controller comparison experiment | REQ-NFR-007 (demo) | inspection | WP-20/21 | no |
+| WP-23 | phase-6-8.md | Sweep driver (YAML, parallel) | REQ-ANA-001/002 | TC-ANA-001 | WP-19 | no |
+| WP-24 | phase-6-8.md | Payload estimation testbed | REQ-ANA-003 | TC-ANA-002 | WP-23 | no |
+
+Reverse map (requirement → WP): every REQ appears in exactly one WP's
+"Implements" column above except cross-cutting REQ-NFR-005 (test discipline —
+every WP) and REQ-NFR-006 (legacy untouched — enforced by the Common Briefing
+hard rule + TC-LEG-001 run at phase exits by the dispatcher).
+
+**Phases 6–8 briefs are intentionally lighter** (marked ELABORATE-BEFORE-DISPATCH):
+they depend on findings from phases 0–4; the dispatcher expands them (same format)
+before dispatching, using accumulated findings.md.

--- a/docs/design/sim-framework/execution/phase-0.md
+++ b/docs/design/sim-framework/execution/phase-0.md
@@ -1,0 +1,67 @@
+# Phase 0 Work Packages
+
+## WP-01 — Scaffold, dependencies, smoke test
+
+**Implements**: REQ-NFR-004, REQ-NFR-005 (foundation). **Depends on**: none.
+
+**Read first**: `requirements.txt`, `docs/design/sim-framework/design.md` §"Package layout" (in plan.md).
+
+**Deliverables**
+- `requirements.txt`: append `mujoco==3.10.0` and `pytest==8.*` (keep existing pins untouched)
+- Run `./.venv/bin/pip install -r requirements.txt` and confirm success
+- Directories with empty `__init__.py`: `icbench/`, `icbench/sim/`, `icbench/control/`, `icbench/tasks/`, `icbench/viz/`, `icbench/analysis/`
+- `experiments/` and `tests/` directories (no `__init__.py` needed in `experiments/`)
+- `tests/test_smoke.py`:
+
+```python
+def test_imports():
+    import mujoco
+    import pinocchio
+    import icbench
+    assert mujoco.__version__ == "3.10.0"
+```
+
+**Acceptance**: `./.venv/bin/pytest tests/ -q` → 1 passed.
+**Commit**: `feat: package scaffold, mujoco dependency, smoke test`
+
+---
+
+## WP-02 — Spike: URDF → MuJoCo compile, EGL headless (throwaway code, durable findings)
+
+**Implements**: resolves design risks R-1, R-2, R-5. **Depends on**: WP-01.
+
+**Read first**: `docs/design/sim-framework/design.md` §3.1 and §6 (risks).
+
+**Context**: MuJoCo cannot resolve `package://` mesh URIs or load DAE meshes.
+The UR5 URDF lives inside the venv (find it):
+`./.venv/lib/python3.12/site-packages/cmeel.prefix/share/example-robot-data/robots/ur_description/urdf/ur5_robot.urdf`
+(verify exact name with `find .venv -name "ur5*.urdf"`). All mesh references are
+`package://example-robot-data/...`; the share root is
+`.../cmeel.prefix/share/example-robot-data/` — the path prefix pinocchio's
+loaders use.
+
+**Steps** (script in scratch space or `/tmp`, NOT committed):
+1. Read the URDF; rewrite `package://example-robot-data/` → absolute share path;
+   write to a temp file.
+2. Try `spec = mujoco.MjSpec.from_file(tmp_urdf)`; if the mjSpec URDF path fails,
+   try `mujoco.MjModel.from_xml_path(tmp_urdf)` and note which works.
+3. Report: does compilation succeed with DAE `<visual>` entries present
+   (discardvisual behavior)? If not, strip `<visual>` elements and retry.
+4. Check compiler behavior with inertia balancing disabled if the API exposes it
+   on this path (`spec.compiler.balanceinertia = False` or MJCF equivalent);
+   note whether UR5 inertias compile without "fixing".
+5. Print and record: joint names in MuJoCo order; `model.nq`, `model.nv`;
+   number of actuators (expect 0); mesh count.
+6. EGL: `MUJOCO_GL=egl ./.venv/bin/python -c "import mujoco; r=mujoco.Renderer(model); ..."`
+   render one offscreen frame from the compiled model; note pass/fail.
+
+**Deliverables**: `docs/design/sim-framework/findings.md` — new section
+"Phase 0 spike (WP-02)" answering ALL of: which load API works for URDF; visual/DAE
+handling; balanceinertia behavior + whether UR5 inertias are consistent; MuJoCo
+joint order vs URDF order (list both); EGL result. If any answer contradicts a
+design assumption (design.md §3.1), say so explicitly in the findings — do not
+silently adapt.
+
+**Acceptance**: findings.md section exists and answers all six questions;
+no code committed other than findings.md.
+**Commit**: `docs: phase 0 spike findings (URDF->MuJoCo, EGL)`

--- a/docs/design/sim-framework/execution/phase-1.md
+++ b/docs/design/sim-framework/execution/phase-1.md
@@ -1,0 +1,171 @@
+# Phase 1 Work Packages
+
+Prerequisite for all WPs here: read `docs/design/sim-framework/findings.md`
+§"Phase 0 spike" — it overrides any assumption below that it contradicts.
+
+## WP-03 — `icbench/models.py`: URDF preprocessing, registry, joint map
+
+**Implements**: REQ-MDL-001..004. **Acceptance tests**: TC-MDL-001/002/003.
+**Depends on**: WP-02.
+
+**Read first**: design.md §3.1; verification.md TC-MDL-001..003; findings.md.
+
+**Deliverables**: `icbench/models.py`, `tests/test_models.py`.
+
+**Specification**
+```python
+@dataclass(frozen=True)
+class RobotBundle:
+    name: str
+    pin_robot: "pinocchio.RobotWrapper"   # with visual (DAE) model for meshcat
+    urdf_mj_path: str                     # preprocessed URDF for MuJoCo
+    mesh_dir: str
+    joint_names: list[str]                # canonical (pinocchio) order, movable joints only
+    mj_from_canon: np.ndarray             # index arrays, see below
+    canon_from_mj: np.ndarray
+    effort_limits: np.ndarray             # (nv,) from URDF <limit effort>
+
+def load_robot(name: str = "ur5") -> RobotBundle: ...
+```
+- Locate URDF + share dir as in WP-02 (make the lookup a helper; don't hardcode
+  the venv path — derive from `example_robot_data`'s installed location or by
+  importing pinocchio's example-robot-data loader package).
+- Preprocess to a cached temp file (`tempfile.mkdtemp` per process is fine):
+  rewrite `package://example-robot-data/` → share path; strip `<visual>` blocks
+  iff findings.md says MuJoCo needs that.
+- Build pin robot via `example_robot_data.load(name)` (gives visual model too).
+- Build MuJoCo model using the API findings.md validated; disable inertia
+  balancing per findings.
+- Joint map: match by joint NAME between `pin_robot.model.names` (skip
+  "universe") and MuJoCo joint names. Raise `ValueError` naming the joint on any
+  mismatch. Raise on `pin.nq != pin.nv` (continuous joints unsupported).
+- Effort limits: parse URDF `<limit effort="...">` per joint (canonical order).
+- Guard (REQ-MDL-004): parse URDF `<dynamics>`; raise if damping/friction ≠ 0.
+
+**Tests** (write first)
+- TC-MDL-001: `load_robot("ur5")`: nq==nv==6; preprocessed file contains no
+  `package://`; MuJoCo model compiles (import the MuJoCo build here).
+- TC-MDL-002: joint-name lists on both sides match under the map;
+  `canon_from_mj[mj_from_canon] == arange(6)` (round-trip identity).
+- TC-MDL-003: synthetic minimal URDF (write in test tmpdir) with
+  `<dynamics damping="0.5">` → `ValueError` naming the joint.
+
+**Commit**: `feat: robot model registry with URDF preprocessing and joint map`
+
+---
+
+## WP-04 — `icbench/sim/scene.py`: actuators + ee sensor `[parallel-ok]`
+
+**Implements**: REQ-MDL-005. **Acceptance**: TC-MDL-004. **Depends on**: WP-03.
+
+**Read first**: design.md §3.2; findings.md (mjSpec editing capabilities).
+
+**Deliverables**: `icbench/sim/scene.py`, `tests/test_scene.py`.
+
+**Specification**
+```python
+def attach_actuators(spec, bundle, use_effort_limits: bool = True) -> None:
+    # one <motor> per movable joint; gear=1; ctrl = joint torque [N·m]
+    # forcerange = ±effort_limits[i] when use_effort_limits (DD-9)
+
+def add_ee_site_and_ft_sensor(spec, body_name: str = "ee_link", site_name: str = "ee") -> None:
+    # site at the ee body frame origin; force + torque sensors on that site
+
+def add_floor(spec) -> None: ...        # called ONLY by Tasks (DD-8)
+def add_wall(spec, pos, size, friction) -> None: ...  # stub now, used in WP-16
+```
+- Work on the mjSpec level (edit → `spec.compile()`); if findings.md says mjSpec
+  URDF editing is unavailable, the documented fallback is: compile URDF →
+  `mj_saveLastXML` → parse MJCF string → inject XML elements → recompile. Follow
+  findings.md.
+
+**Tests**
+- TC-MDL-004: compiled model: `model.nu == 6`; `actuator_forcerange` rows equal
+  ±effort limits; with `use_effort_limits=False` ranges are unbounded (0,0 or
+  ±inf per MuJoCo convention — assert actual behavior and document in a comment).
+- Sensor: model has force+torque sensors on site "ee"; floor absent unless
+  `add_floor` called.
+
+**Commit**: `feat: scene builders (torque actuators with effort limits, ee F/T sensor)`
+
+---
+
+## WP-05 — `icbench/types.py` + `icbench/sim/world.py`: World core
+
+**Implements**: REQ-SIM-001/002/003/005/006. **Acceptance**: TC-SIM-001..004.
+**Depends on**: WP-03, WP-04.
+
+**Read first**: design.md §2.1, §3.3; verification.md TC-SIM-001..004;
+Conventions in plan.md.
+
+**Deliverables**: `icbench/types.py` (State, Reference dataclasses exactly per
+design.md §2.1), `icbench/sim/world.py`, `tests/test_world.py`.
+
+**Specification**
+```python
+class World:
+    def __init__(self, bundle, scene_hook=None, dt_phys=0.002):
+        # scene_hook: callable(spec) -> None, applied before compile (Tasks use this)
+    def reset(self, q0: np.ndarray) -> None: ...          # canonical order
+    def step(self, tau: np.ndarray, n_substeps: int) -> None:
+        # canonical -> mj order -> data.ctrl; mj_step * n_substeps
+        # re-apply any active external wrench each substep
+    def state(self) -> State: ...                          # canonical
+    def ee_wrench(self) -> np.ndarray:
+        # (6,) [force, torque]; sensor frame -> world axes via site xmat;
+        # sign: robot-on-environment positive (flip sensor sign accordingly —
+        # MuJoCo F/T sensors report child-on-parent; VERIFY empirically in the
+        # static test and document the flip in a comment)
+    def contacts(self) -> list:  # raw mjContact view; docstring MUST state
+        # MuJoCo contact frame: X axis is the contact normal
+    def apply_external_wrench(self, wrench: np.ndarray, body: str = "ee_link") -> None:
+        # sets data.xfrc_applied[body_id]; persists until cleared
+    def clear_external_wrench(self) -> None: ...
+```
+- No gravity logic anywhere (REQ-SIM-006). No floor by default (DD-8).
+
+**Tests** (empty scene unless stated)
+- TC-SIM-001 free fall: `reset(q_home)`, zero torque, one step: `ddq` from
+  finite-difference matches `pin: aba(q, 0, 0)` within 1e-3 rel. (uses pin as
+  oracle); 1 s of falling produces no NaN and no contacts.
+- TC-SIM-002 torque causality: gravity-feedforward `tau = pin.g(q)` holds the
+  arm (‖dq‖ < 1e-2 after 0.5 s); adding +5 N·m on joint 0 accelerates joint 0
+  positive.
+- TC-SIM-003 wrench frame/sign: attach a 2 kg point mass to the ee body in the
+  scene_hook; hold arm with gravity feedforward computed for the *unloaded*
+  model plus a position-holding high-gain joint PD (keep it crude and stiff —
+  this is a fixture, not a controller); after settling, `ee_wrench()` force ≈
+  (0, 0, −2·9.81) world axes within 5% → robot-on-env positive means the sensor
+  reads the load's weight with the documented sign. Repeat at a 90°-rotated
+  wrist pose: still world-aligned (this catches missing xmat rotation).
+- TC-SIM-004 external wrench: gravity-held arm; `apply_external_wrench`
+  (+20 N world x at ee) → ee moves +x; `clear_external_wrench()` → returns
+  toward start (‖err‖ shrinking for 1 s).
+
+**Commit**: `feat: World core (canonical remap, wrench sensing, external wrench)`
+
+---
+
+## WP-06 — Cross-engine anchor tests
+
+**Implements**: REQ-NFR-001 (+ REQ-MDL-004 via TC-CE-004). **Acceptance**:
+TC-CE-001..004. **Depends on**: WP-05.
+
+**Read first**: verification.md §TC-CE-*; design.md DD-3.
+
+**Deliverables**: `tests/test_cross_engine.py`.
+
+**Specification** — all with `rng = np.random.default_rng(20260717)`; 20 states
+sampled within joint limits; comparisons in canonical order; relative tolerance
+1e-6 (`np.testing.assert_allclose(..., rtol=1e-6, atol=1e-10)`).
+- TC-CE-001: `pin.computeGeneralizedGravity(q)` vs mj `qfrc_bias` with
+  `data.qvel[:]=0` after `mj_forward` (map order; mind sign conventions —
+  MuJoCo `qfrc_bias` = C(q,dq)dq + g(q) with *positive* sign; pinocchio
+  `nle`/`g` likewise; assert equality, and if a systematic sign flip appears,
+  STOP and report rather than absorbing it silently).
+- TC-CE-002: nonzero seeded `dq`: `pin.nonLinearEffects(q, dq)` vs `qfrc_bias`.
+- TC-CE-003: `pin.crba(q)` (symmetrize) vs `mj_fullM` dense.
+- TC-CE-004: `data.qfrc_passive == 0` exactly, at all sampled states.
+
+**Acceptance**: suite green; runtime of these tests < 10 s.
+**Commit**: `test: cross-engine consistency anchors (gravity, nle, mass matrix, passive)`

--- a/docs/design/sim-framework/execution/phase-2.md
+++ b/docs/design/sim-framework/execution/phase-2.md
@@ -1,0 +1,253 @@
+# Phase 2 Work Packages
+
+## WP-07 — `icbench/control/ctrl_model.py` `[parallel-ok]`
+
+**Implements**: REQ-CTL-002. **Acceptance**: TC-CTL-002. **Depends on**: WP-06.
+
+**Read first**: design.md §3.4; legacy `controllers/impedance_6dof.py` lines
+130–200 (what quantities controllers consume).
+
+**Deliverables**: `icbench/control/ctrl_model.py`, `tests/test_ctrl_model.py`.
+
+**Specification**
+```python
+class CtrlModel:
+    def __init__(self, bundle, ee_frame: str = "ee_link"): ...
+    def mass(self, q) -> np.ndarray            # pin.crba, symmetrized
+    def nle(self, q, dq) -> np.ndarray         # pin.nonLinearEffects
+    def gravity(self, q) -> np.ndarray         # pin.computeGeneralizedGravity
+    def coriolis(self, q, dq) -> np.ndarray    # pin.computeCoriolisMatrix (matrix!)
+    def frame_jacobian(self, q) -> np.ndarray  # LOCAL_WORLD_ALIGNED, ee frame
+    def frame_jacobian_dot(self, q, dq) -> np.ndarray
+    def fk(self, q) -> "pin.SE3"
+```
+All canonical order. Stateless between calls (each method does its own
+`forwardKinematics`/compute as needed — correctness over micro-perf).
+
+**Tests**
+- Each method vs direct pinocchio calls at 3 fixture states (one = legacy home
+  pose `[0, -1, 1.2, -(π+0.2), -π/2, 0]`), exact match.
+- Coriolis property: `Ṁ − 2C` skew-symmetric at 5 seeded random (q, dq):
+  `M_dot ≈ (M(q + dq·h) − M(q))/h` with h=1e-7, assert
+  `‖(Ṁ − 2C) + (Ṁ − 2C)ᵀ‖ < 1e-4` (loose tol: finite difference).
+
+**Commit**: `feat: control-side pinocchio model wrapper`
+
+---
+
+## WP-08 — Controller ABC + config dataclasses `[parallel-ok]`
+
+**Implements**: REQ-CTL-001, REQ-CTL-007. **Acceptance**: TC-CTL-007.
+**Depends on**: WP-06.
+
+**Deliverables**: `icbench/control/base.py`, `tests/test_control_base.py`.
+
+**Specification**
+```python
+class ControllerConfig:  # base for all controller configs
+    @classmethod
+    def from_dict(cls, d: dict): ...   # dataclasses.fields-driven; unknown keys -> ValueError
+    def to_dict(self) -> dict: ...
+
+class Controller(ABC):
+    control_rate_hz: float             # class attr, overridable via config
+    def __init__(self, ctrl_model, config): ...
+    @abstractmethod
+    def reset(self, state0: State) -> None: ...
+    @abstractmethod
+    def compute(self, state: State, ref: Reference, t: float, dt: float) -> np.ndarray:
+        """Returns TOTAL joint torque (canonical order) INCLUDING gravity/nle
+        compensation. The plant is real — see DD-2."""
+```
+
+**Tests**: TC-CTL-007 — a sample config: dict → dataclass → dict lossless;
+unknown key raises with the key named.
+
+**Commit**: `feat: controller ABC and config dataclass machinery`
+
+---
+
+## WP-09 — Task-space impedance (reformulated) + damped pinv
+
+**Implements**: REQ-CTL-003/004/005. **Acceptance**: TC-CTL-003/005/006.
+**Depends on**: WP-07, WP-08.
+
+**Read first**: legacy `controllers/impedance_6dof.py` lines 236–276 (the three
+variants); design.md §3.5; the two verified legacy bugs in plan.md
+§"Key technical facts".
+
+**Deliverables**: `icbench/control/impedance.py`,
+`icbench/control/kinematics.py` (damped pinv), `tests/test_impedance.py`,
+derivation notes appended to findings.md.
+
+**Specification**
+
+`kinematics.py`:
+```python
+def damped_pinv(J, lam0=0.05, w_threshold=0.02) -> np.ndarray:
+    # J^T (J J^T + λ² I)^-1 ; λ = lam0 * (1 - w/w_threshold) if w < w_threshold else ~0
+    # w = sqrt(det(J J^T)) manipulability
+```
+
+`impedance.py` — `TaskSpaceImpedance(ctrl_model, config)`, `variant ∈ {2,3,4}`:
+- Error terms exactly as legacy (lines 236–237): `x_err = [x_des − x;
+  rpy(R_des·Rᵀ)]`, `v_err = v_des − J·dq`.
+- Variant 4 (`control_rate_hz=100` default): `tau = Jᵀ(Kd·x_err + Dd·v_err) + g(q)`
+  — the `+g(q)` replaces the legacy plant's hidden compensation (DD-2).
+- Variant 3 (100 Hz): as legacy `inverse_dyn + interaction_port` BUT: gravity
+  handled explicitly (net effect documented in the derivation), the legacy term
+  `(h − g − M·Ji·dJ) @ Ji @ v_des` (a vector−matrix broadcast bug, legacy lines
+  262/270) replaced by `(C(q,dq) − M·J⁺·dJ)·J⁺·v_des` with `C` the Coriolis
+  MATRIX; all `inv(J)` → `damped_pinv(J)`.
+- Variant 2 (`control_rate_hz=1000`): same corrections + the `Md`/inertia-ratio
+  port from legacy lines 96–102, 255–260.
+- Gains in `ImpedanceConfig` (defaults = legacy values per variant).
+- Write the variant-by-variant derivation (legacy form → reformulated form,
+  including where `g` moves and why the Coriolis term changes) into findings.md
+  §"Impedance reformulation (WP-09)". This is a REQUIRED deliverable (REQ-CTL-003
+  is verified partly by Analysis).
+
+**Tests**
+- TC-CTL-003 golden fixtures: at ≥3 states incl. dq≠0 (fixture file with
+  hardcoded arrays): unchanged terms (x_err, v_err, Jᵀ·F mapping for variant 4
+  minus the g term) equal values computed by transliterating the legacy lines
+  inside the test; reformulated terms equal an independent in-test computation
+  of the corrected formula (do not import the implementation's own helper for
+  the expected value — write the formula out).
+- TC-CTL-005: singular pose (elbow straight): `damped_pinv` bounded
+  (‖J⁺‖ < 1e3), continuous around the threshold (sweep w through w_threshold,
+  no jump > 10% between adjacent samples).
+- TC-CTL-006: variant 2 config default rate 1000 Hz; variants 3/4 → 100 Hz.
+
+**Commit**: `feat: reformulated task-space impedance variants with damped pinv`
+
+---
+
+## WP-10 — Legacy closed-loop parity test
+
+**Implements**: REQ-CTL-003 (port faithfulness), REQ-NFR-006. **Acceptance**:
+TC-CTL-004. **Depends on**: WP-09.
+
+**Deliverables**: `tests/test_legacy_parity.py`.
+
+**Specification** — replicate the legacy PLANT exactly inside the test (this is
+the one place the hidden-gravity plant is intentionally reproduced):
+```python
+# legacy plant replica: ddq = pin.aba(model, data, q, dq, tau + g(q)); Euler, dt=0.01
+```
+Run 200 steps (2 s) from the legacy home pose with regulation reference:
+1. Reference trajectory: transliterate legacy variant-4 controller inline in the
+   test (lines 273–276: `tau = Jᵀ(Kd·x_err + Dd·v_err)`, legacy gains).
+2. Candidate: `TaskSpaceImpedance(variant=4).compute(...)` **minus**
+   `ctrl_model.gravity(q)` (removing the package's explicit g-comp recovers the
+   legacy torque in the legacy plant).
+Assert `‖q_legacy(t) − q_candidate(t)‖∞ < 1e-9` at every step (identical math,
+identical integrator ⇒ near-machine agreement).
+
+**Commit**: `test: closed-loop parity of ported impedance vs legacy plant replica`
+
+---
+
+## WP-11 — Task ABC + free-space task `[parallel-ok]`
+
+**Implements**: REQ-TSK-001/002. **Depends on**: WP-08 (Reference type from WP-05's types.py).
+
+**Read first**: design.md §3.6; legacy lines 88–95 (dt), 172–186 (dynamic_ref),
+229–233 (disturbance).
+
+**Deliverables**: `icbench/tasks/base.py`, `icbench/tasks/free_space.py`,
+`tests/test_tasks.py`.
+
+**Specification**
+```python
+class Task(ABC):
+    def build_scene(self, spec) -> None: ...      # ALL env geometry (incl. floor)
+    @abstractmethod
+    def reference(self, t: float) -> Reference: ...
+    @abstractmethod
+    def metrics(self, log: dict[str, np.ndarray]) -> dict: ...
+    def disturbance(self, t: float) -> np.ndarray | None:  # world wrench at ee or None
+        return None
+
+@dataclass
+class FreeSpaceConfig: mode: str = "regulation"  # or "sinusoid"
+    # sinusoid: legacy ref_freq=0.3 Hz, ref_ampl=0.10 m on y/z (lines 173-185)
+    # disturbance: legacy fe_amp = 9.80665*5.0 N, fe_angf = 3.0 (lines 89-91, 231-233)
+    disturbance_on: bool = False
+```
+`FreeSpace.build_scene` adds NOTHING (empty world — DD-8). `metrics`: tracking
+RMSE of `ee_pos` vs `ref_pos` (skip first 0.2 s), max abs error.
+
+**Tests**: reference continuity (‖ref(t+h)−ref(t)‖ → 0 as h→0 at 10 seeded t);
+regulation mode returns constant pose; disturbance returns legacy sine values at
+t = 0.5 s (hand-computed expected value in test).
+
+**Commit**: `feat: task ABC and free-space task with legacy-parity disturbance`
+
+---
+
+## WP-12 — Runner + LogSchema + determinism
+
+**Implements**: REQ-EXP-001, REQ-SIM-007, REQ-NFR-003. **Acceptance**:
+TC-EXP-001, TC-SIM-005, TC-SYS-001, TC-SYS-002, TC-CTL-001.
+**Depends on**: WP-09, WP-11 (and WP-05).
+
+**Read first**: design.md §2.2 (LogSchema — channel names are a CONTRACT), §3.8.
+
+**Deliverables**: `icbench/runner.py`, `tests/test_runner.py`,
+`tests/test_system_freespace.py`.
+
+**Specification**
+```python
+class Experiment:
+    def __init__(self, bundle, task, controller, viewer=None, dt_phys=0.002, seed=0): ...
+    def run(self, duration: float) -> tuple[dict[str, np.ndarray], dict]:
+        # returns (log, metrics)
+```
+- dt_ctrl = 1/controller.control_rate_hz; `n_substeps = round(dt_ctrl/dt_phys)`;
+  raise if not integer within 1e-9.
+- Loop exactly as design.md §5 sequence diagram; task.disturbance(t) applied via
+  `World.apply_external_wrench` each control step (or cleared when None).
+- Log: preallocate/append ALL channels of design.md §2.2 with those exact names.
+- Viewer optional (None = headless); `viewer.sync(state)` best-effort.
+
+**Tests**
+- TC-EXP-001: log has exactly the documented channels & shapes; a
+  `FreeSpace.metrics(log)` call consumes it unmodified.
+- TC-CTL-001 gravity hold: variant 4, regulation at home pose, 5 s headless:
+  max ‖ee_pos − ref‖ < 5 mm after the first 0.5 s. (THE acid test for DD-2.)
+- TC-SYS-001: variant 3 and 4, sinusoid mode, 4 s: RMSE finite, < recorded
+  baseline (record baseline on first green run into the test as a constant with
+  a comment; treat later regressions > 20% as failures).
+- TC-SYS-002: disturbance_on: log `ee_wrench_ft` shows the injected sine
+  (correlate: peak frequency ≈ fe_angf/2π Hz).
+- TC-SIM-005 determinism: two identical runs (same seed) → all log arrays
+  `np.array_equal` (bitwise).
+
+**Commit**: `feat: experiment runner with fixed log schema; system tests (gravity hold, tracking, determinism)`
+
+---
+
+## WP-13 — experiments/_common.py + free-space script + README
+
+**Implements**: REQ-EXP-002/003, REQ-NFR-002 (measurement). **Acceptance**:
+TC-VAL-002 + inspection. **Depends on**: WP-12.
+
+**Deliverables**: `experiments/_common.py`, `experiments/impedance_free_space.py`,
+README section, findings.md RTF entry.
+
+**Specification**
+- `_common.py`: `build_argparser()` with `--seed int=0`, `--viewer
+  {none,mujoco,meshcat}=none` (choices exist now; mujoco/meshcat raise
+  NotImplementedError until Phase 3), `--record` (stored, unused until Phase 5),
+  `--duration float`.
+- `impedance_free_space.py`: `--variant {2,3,4}`, builds Experiment, runs,
+  prints metrics dict, shows matplotlib figure (ee error + wrench channels vs t)
+  unless `--no-plot`.
+- Time a 10 s headless run (`time.perf_counter` around `run`) and append the
+  real-time factor to findings.md §"RTF (WP-13)" (TC-VAL-002).
+- README.md: new section "Simulation package (icbench)" — one paragraph +
+  run example command; state legacy scripts unchanged.
+
+**Acceptance**: script runs green end-to-end headless; README updated;
+RTF recorded. **Commit**: `feat: free-space experiment script and shared CLI conventions`

--- a/docs/design/sim-framework/execution/phase-3.md
+++ b/docs/design/sim-framework/execution/phase-3.md
@@ -1,0 +1,91 @@
+# Phase 3 Work Packages
+
+## WP-14 — MuJoCo native viewer `[parallel-ok]`
+
+**Implements**: REQ-VIZ-001, REQ-VIZ-003. **Acceptance**: TC-VIZ-001 (demo),
+TC-VIZ-004. **Depends on**: WP-12.
+
+**Read first**: design.md §3.7; `icbench/runner.py` (viewer call sites).
+
+**Deliverables**: `icbench/viz/base.py`, `icbench/viz/mujoco_viewer.py`,
+runner/`_common.py` wiring, `tests/test_viz.py` (headless parts only).
+
+**Specification**
+```python
+class Viewer(ABC):
+    @abstractmethod
+    def sync(self, state: State) -> None: ...
+    @abstractmethod
+    def close(self) -> None: ...
+
+class MujocoViewer(Viewer):
+    def __init__(self, world):  # mujoco.viewer.launch_passive(world.model, world.data)
+    # sync(): viewer.sync(); pace to wall clock: sleep max(0, t_sim - t_wall);
+    # never slow physics below data availability — drop frames instead.
+```
+- Wire `--viewer mujoco` in `_common.py` → construct MujocoViewer;
+  `--viewer none` stays default.
+- TC-VIZ-004 (automated): run a 1 s experiment with `--viewer none` in an env
+  with `DISPLAY` and `WAYLAND_DISPLAY` unset (subprocess with scrubbed env) —
+  exit 0.
+
+**Manual demo (TC-VIZ-001)** — document the steps + expected observations at the
+end of `docs/design/sim-framework/findings.md` §"Viewer demos", leave a checkbox
+for the human: full arm visible, motion smooth, no missing geometry.
+
+**Commit**: `feat: MuJoCo passive viewer backend`
+
+---
+
+## WP-15 — meshcat patch module + meshcat viewer `[parallel-ok]`
+
+**Implements**: REQ-VIZ-002, REQ-VIZ-004. **Acceptance**: TC-VIZ-002 (demo),
+TC-VIZ-003. **Depends on**: WP-12. **This WP MAY edit the legacy script** (import
+switch only — explicitly allowed here, overriding the common rule).
+
+**Read first**: `controllers/impedance_6dof.py` lines 27–52 (the existing patch
+function `_patch_meshcat_viewer_bundle` and viewer init); design.md §3.7, DD-7.
+
+**Deliverables**: `icbench/viz/meshcat_patch.py`, `icbench/viz/meshcat_viewer.py`,
+edit to `controllers/impedance_6dof.py` (replace its inline patch function with
+`from icbench.viz.meshcat_patch import patch_meshcat_viewer_bundle` — keep
+behavior identical), `tests/test_meshcat_patch.py`.
+
+**Specification**
+
+`meshcat_patch.py` — move the existing function, upgrading its behavior:
+```python
+BROKEN = "i.push(t.geometry),n.push(t.material)"
+FIXED  = "i.push(t.geometry),n.push(Array.isArray(t.material)?t.material[0]:t.material)"
+def patch_meshcat_viewer_bundle() -> str:  # returns "patched"|"already-patched"|"unknown-bundle"
+    # unknown-bundle => print LOUD warning (REQ-VIZ-004): bundle matches neither
+    # pattern; meshes may render partially; do not modify the file.
+```
+
+`meshcat_viewer.py`:
+- Calls `patch_meshcat_viewer_bundle()` on init.
+- Builds pin `MeshcatVisualizer` from `bundle.pin_robot` (DAE visual model),
+  `initViewer(open=False)`, `viewer.delete()` then `loadViewerModel()` (stale
+  scene clear — same rationale as legacy), atexit server cleanup (mirror legacy
+  lines 46–53 behavior).
+- `sync(state)`: `viz.display(q)` (canonical q is what pin expects).
+- Scene mirroring: read optional `task.meshcat_props() -> list[dict]` (boxes
+  only: pos/size/rgba); render via `viewer["props/i"].set_object(Box…)`;
+  document best-effort status (DD-7).
+
+**Tests** (TC-VIZ-003, no browser needed — operate on a copied bundle file):
+- fixture: copy the real `main.min.js` to tmp; monkeypatch the module's path
+  discovery to the copy.
+- pristine copy (restore BROKEN string first) → returns "patched", file contains
+  FIXED; second call → "already-patched", file unchanged (hash equal).
+- bundle with neither string (write garbage file) → "unknown-bundle", file
+  unchanged, warning on stderr (capsys).
+- Inspection item: legacy script still runs (`echo "" | ./.venv/bin/python
+  controllers/impedance_6dof.py` exit 0) — include as an automated subprocess
+  test.
+
+**Manual demo (TC-VIZ-002)**: findings.md checklist — meshcat shows FULL arm
+(shoulder/wrist housings present — regression vs the merge_geometries bug),
+motion matches MuJoCo viewer for the same run.
+
+**Commit**: `feat: meshcat viewer backend with centralized bundle patch`

--- a/docs/design/sim-framework/execution/phase-4.md
+++ b/docs/design/sim-framework/execution/phase-4.md
@@ -1,0 +1,88 @@
+# Phase 4 Work Packages
+
+## WP-16 — Wall scene + wall-contact task + experiment
+
+**Implements**: REQ-TSK-003, REQ-SIM-004. **Acceptance**: TC-SYS-003.
+**Depends on**: WP-13.
+
+**Read first**: design.md §3.6 (WallContact), §3.3 (`contacts()` accessor,
+X-normal warning); verification.md TC-SYS-003.
+
+**Deliverables**: finish `add_wall` in `icbench/sim/scene.py`, add
+`World.ee_contact_wrench()` (ground-truth channel), `icbench/tasks/wall_contact.py`,
+`experiments/impedance_wall_contact.py`, `tests/test_wall_contact.py`.
+
+**Specification**
+- `add_wall(spec, pos, size, friction)`: static box geom; default: vertical wall
+  0.15 m in front of the ee home position (compute from FK at build time), size
+  (0.02, 0.5, 0.5) m, friction 0.8.
+- `World.ee_contact_wrench()`: sum `mj_contactForce` over contacts involving any
+  robot geom and the wall geom, mapped to world axes. **The MuJoCo contact frame
+  has the normal along X — document this in the accessor docstring and handle
+  the rotation via the contact frame matrix.** Sign: robot-on-wall positive.
+  Log channel name: `ee_wrench_contact` (contract, design.md §2.2).
+- `WallContact(config)`: phases — approach (Cartesian ramp to a point 2 cm
+  *behind* the wall surface → guarantees contact), press (hold pose ref;
+  `wrench_des` ramps 0→20 N normal over 0.5 s then holds). `reference(t)`
+  returns pose + wrench_des. `metrics(log)`: from `ee_wrench_contact` normal
+  component after contact: steady-state error (last 1 s mean vs target),
+  overshoot (%), settling time (into ±10% band). `build_scene`: floor + wall.
+  `meshcat_props()`: the wall box.
+- Control default: 1 kHz (REQ-CTL-004) — pass through config.
+- `experiments/impedance_wall_contact.py`: `--variant {2,3,4}`, plots: normal
+  force (ft + contact channels overlaid) vs t, ee position vs t.
+
+**Tests** (TC-SYS-003, headless, variant 4, 4 s):
+- run completes; contact established (max normal force > 5 N);
+- steady-state |error| < 2 N vs 20 N target;
+- metrics dict has exactly {steady_state_error_n, overshoot_pct, settling_time_s};
+- `ee_wrench_contact` ≈ `ee_wrench_ft` normal components within 20% during
+  steady press (cross-validates the two sensing paths).
+
+**Commit**: `feat: wall-contact task with ground-truth contact wrench`
+
+---
+
+## WP-17 — Surface-slide task `[parallel-ok]`
+
+**Implements**: REQ-TSK-004. **Acceptance**: TC-SYS-004. **Depends on**: WP-16.
+
+**Deliverables**: `icbench/tasks/surface_slide.py`,
+`experiments/impedance_surface_slide.py`, `tests/test_surface_slide.py`.
+
+**Specification**
+- Horizontal table surface (reuse `add_wall` with horizontal pose or add
+  `add_table`); ee presses down (wrench_des = 10 N normal) while pose ref
+  traverses a 0.2 m straight line in 3 s.
+- Metrics: normal-force RMSE during the slide, path-following RMSE (tangential),
+  path completion fraction.
+- Test (TC-SYS-004): variant 4, run completes; force RMSE finite and
+  < recorded baseline (record on first green run, comment in test); completion
+  > 95%.
+
+**Commit**: `feat: constant-force surface-slide task`
+
+---
+
+## WP-18 — Validation: stiffness sweep + effort-limit study `[parallel-ok]`
+
+**Implements**: validation of REQ-TSK-003, REQ-MDL-005. **Acceptance**:
+TC-VAL-001, TC-VAL-003 (Analysis — findings, not pytest). **Depends on**: WP-16.
+
+**Deliverables**: `experiments/validation_stiffness_sweep.py`; findings.md
+sections "Stiffness/penetration trend (TC-VAL-001)" and "Effort-limit effect
+(TC-VAL-003)".
+
+**Specification**
+- Sweep variant-4 normal stiffness Kd_n ∈ {300, 900, 2500, 5000} N/m on
+  WallContact (headless, fixed seed); collect steady-state penetration
+  (ee position past wall surface plane) and force error.
+- Assert-in-script (not pytest): penetration strictly decreasing with Kd_n;
+  print table; append a markdown table + 3-sentence interpretation to
+  findings.md. Note any contact chatter (R-3) and, if observed, the
+  solref/solimp values that resolved it.
+- Effort-limit study: WallContact with `use_effort_limits` True vs False,
+  Kd_n=5000: report max |tau| per joint and whether clipping engaged
+  (`tau` vs actuator forcerange in log); 3 sentences in findings.md.
+
+**Commit**: `docs: contact validation studies (stiffness trend, effort limits)`

--- a/docs/design/sim-framework/execution/phase-5.md
+++ b/docs/design/sim-framework/execution/phase-5.md
@@ -1,0 +1,37 @@
+# Phase 5 Work Package
+
+## WP-19 — Recorder + gitignore
+
+**Implements**: REQ-REC-001, REQ-REC-002. **Acceptance**: TC-REC-001.
+**Depends on**: WP-12 (LogSchema contract).
+
+**Read first**: design.md §2.3 (run artifact layout — exact), §3.9.
+
+**Deliverables**: `icbench/recording.py`, `.gitignore` entry `data/runs/`,
+`--record` wiring in `experiments/_common.py`, `tests/test_recording.py`.
+
+**Specification**
+```python
+class Recorder:
+    def save(self, experiment_name: str, config: dict, log: dict, metrics: dict,
+             figures: list = ()) -> Path:
+        # data/runs/<UTC yyyymmddTHHMMSSZ>_<experiment_name>/
+        #   config.json   — config dicts + seed + git SHA (subprocess: git rev-parse HEAD;
+        #                    "unknown" on failure, never crash)
+        #   timeseries.npz — np.savez_compressed(**log)
+        #   metrics.json
+        #   fig_<i>.png   — for each matplotlib figure passed
+```
+- Config dict comes from the dataclass `to_dict()`s (WP-08); include
+  `{"controller": ..., "task": ..., "seed": ..., "git_sha": ...}`.
+- `--record` in `_common.py`: after run, call Recorder with the same figures the
+  interactive path shows; print the run dir path.
+
+**Tests** (TC-REC-001)
+- Record a 0.5 s headless free-space run into a tmp-redirected `data/runs`
+  (monkeypatch base dir): reload npz — every array equal to in-memory log;
+  config.json round-trips to the same dataclasses via `from_dict`; metrics.json
+  equals metrics.
+- Inspection-as-test: assert `data/runs/` appears in `.gitignore`.
+
+**Commit**: `feat: opt-in run recorder with reproducible artifacts`

--- a/docs/design/sim-framework/execution/phase-6-8.md
+++ b/docs/design/sim-framework/execution/phase-6-8.md
@@ -1,0 +1,77 @@
+# Phase 6–8 Work Packages — ELABORATE BEFORE DISPATCH
+
+These briefs are intentionally lighter: they depend on findings from Phases 0–4
+(contact behavior, RTF, solver settings). Before dispatching any WP below, the
+dispatcher expands it to the Phase 1–5 level of detail (same format: Read first /
+Deliverables / Specification / Tests / Commit), folding in findings.md.
+
+## WP-20 — Joint PD + computed torque `[parallel-ok]`
+
+**Implements**: REQ-CTL-006 (part). **Depends on**: WP-12.
+
+Scope when elaborating:
+- `joint_pd.py`: legacy variants 1/5 reformulated (legacy line 252:
+  `tau = M·ddq_des + h + M·(Kp·e + Kd·ė)` — note the legacy plant hid `g`; the
+  port keeps `h = nle` which already contains g, so verify against TC-CTL-001
+  gravity hold). Uses `Reference.q_des/dq_des/ddq_des`.
+- `computed_torque.py`: `tau = M·(ddq_des + Kp·e + Kd·ė) + nle` — this is the
+  admittance inner loop; must hold TC-CTL-001 and track a joint-space chirp
+  (new unit test, tolerance recorded on first green run).
+- Golden-fixture tests per WP-09 pattern; config dataclasses per WP-08.
+
+## WP-21 — Admittance (outer/inner composition)
+
+**Implements**: REQ-CTL-006. **Acceptance**: TC-CTL-008. **Depends on**: WP-16, WP-20.
+
+Scope when elaborating:
+- Outer loop: virtual dynamics `M_v·ẍ + D_v·ẋ + K_v·(x − x_ref) = f_meas`
+  integrated at control rate → motion reference; `f_meas` = `ee_wrench_ft`
+  through a 1st-order low-pass (config cutoff, default ≤ 1/10 of inner-loop
+  bandwidth — compute and document).
+- Inner: `ComputedTorque` at 1 kHz on the outer loop's reference (IK via
+  damped_pinv velocity-level integration).
+- TC-CTL-008: wall task force convergence ±10%, no oscillation growth
+  (amplitude of force oscillation non-increasing over last 2 s), spectrum check
+  confirms low-pass active.
+
+## WP-22 — Controller comparison experiment
+
+**Implements**: REQ-NFR-007 (demonstration). **Depends on**: WP-20/21.
+
+Scope when elaborating:
+- `experiments/controller_comparison.py`: same task (free-space sinusoid AND
+  wall contact) × {impedance 2/3/4, joint PD, computed torque, admittance} →
+  metrics table (markdown to stdout + optional record), overlay plots.
+- Demonstrates REQ-NFR-007: adding a controller touched only its module +
+  config — verify by inspection, note in findings.md.
+
+## WP-23 — Sweep driver
+
+**Implements**: REQ-ANA-001/002. **Acceptance**: TC-ANA-001. **Depends on**: WP-19.
+
+Scope when elaborating:
+- `analysis/sweep.py`: YAML → grid of config dicts (controller/task dataclasses
+  via `from_dict` — zero controller changes, DD-6); `multiprocessing.Pool`
+  headless runs (each with Recorder); aggregate metrics + config columns into
+  `metrics.parquet` (pandas, add to requirements) + markdown report.
+- Disturbance schedules (REQ-ANA-002): time-profiled wrench configs
+  (const/sine/step) as sweepable task parameters over the WP-05 primitive.
+- Payload-mass sweep mechanism: scene_hook adding point mass at ee (reuse
+  TC-SIM-003 fixture machinery) — this is also WP-24's ground-truth knob.
+- TC-ANA-001: 2×2 grid, 4 rows, seeded rerun reproduces metrics bitwise.
+
+## WP-24 — Payload estimation testbed
+
+**Implements**: REQ-ANA-003. **Acceptance**: TC-ANA-002. **Depends on**: WP-23.
+
+Scope when elaborating:
+- `analysis/sysid/payload_estimation.py`: excitation trajectory (joint-space
+  chirp via computed torque); regressor formulation for ee payload
+  (mass [+ com, then inertia] on last link) using CtrlModel terms; batch least
+  squares first, then RLS variant; report estimate vs ground truth (the WP-23
+  payload knob), error %, convergence time.
+- TC-ANA-002: known 2 kg payload estimated within 5% after the documented
+  excitation; test tolerance justified in findings.md.
+- Context note for the implementer: same problem family as Rapyuta lifter
+  weight estimation — the value here is a clean testbed with perfect ground
+  truth; keep estimator code independent of any Rapyuta internals.

--- a/docs/design/sim-framework/plan.md
+++ b/docs/design/sim-framework/plan.md
@@ -1,5 +1,10 @@
 # Experimental Simulation Package — Implementation Plan
 
+*Rev 2 — after adversarial review (2026-07-17). Major changes from rev 1: gravity-
+convention decision, URDF preprocessing task, typed interfaces, conventions
+section, closed-loop parity testing, external-wrench primitive moved to Phase 2,
+config dataclasses from the start, per-controller control rates.*
+
 ## Goal
 
 Evolve this repo from two standalone demo scripts into an **experimental simulation
@@ -8,174 +13,246 @@ many. Target capabilities (in build order): real contact physics, a controller z
 with comparisons, robustness/disturbance batch sweeps, and system-ID/estimation
 testbeds.
 
-## Decisions (agreed 2026-07-17)
+## Decisions (agreed 2026-07-17, extended after review)
 
 | Topic | Decision |
 |---|---|
 | Physics backend | **MuJoCo** (`mujoco==3.10.0`, pip) simulates the world; **Pinocchio** stays for control-side model terms (M, C, g, Jacobians) |
-| Model source | One shared URDF (example-robot-data) loaded into *both* engines → no model mismatch between sim and controller. UR5 first; any example-robot-data arm pluggable by name |
-| Viewer | Both backends, selectable per run: MuJoCo native viewer *and* meshcat (browser). Meshcat reuses the `merge_geometries` bundle patch |
-| Consumption | Interactive-first (live viewer + matplotlib at end). `Recorder` is optional, needed later for batch sweeps |
+| Model source | One shared URDF (example-robot-data) loaded into *both* engines. UR5 first; other example-robot-data arms pluggable by name |
+| **Gravity convention** | **The plant is real: MuJoCo applies gravity, no hidden compensation.** Every controller must output *total* torque including its own gravity/nle compensation (via `ctrl_model`). The legacy script's plant `aba(q, dq, tau + g)` (line 291) secretly cancels gravity — ports must be reformulated, not copied |
+| Control rate | Per-controller/per-task property, not global. Legacy variant 2 was designed at 1 kHz (`wn`=250 rad/s — line 95); contact tasks default to 1 kHz. 100 Hz only for free-space variants 3/4 |
+| Viewer | MuJoCo native viewer is **authoritative** (shows the true physics scene). Meshcat is an optional robot-mirror (pretty DAE visuals; scene props mirrored best-effort only). Selectable per run |
+| Consumption | Interactive-first (live viewer + matplotlib at end). `Recorder` opt-in, required for batch sweeps |
 | First analysis | Contact interaction tasks (wall contact / surface slide) |
 | Repo shape | Python package `icbench/` + thin runnable scripts in `experiments/`. Legacy `controllers/*.py` stay untouched and working |
 
+## Conventions (single source of truth — violations are bugs)
+
+- **Units**: SI throughout (m, s, rad, N, N·m). No degrees anywhere.
+- **Canonical joint order**: the URDF/pinocchio order. `World` owns the
+  mujoco↔canonical remap; `Controller.compute` and `Viewer.sync` always receive
+  canonical-order state. The remap is data (an index map built in `models.py`),
+  never assumed to be identity — pinocchio uses 2 qpos entries for continuous
+  joints, so `pin.nq != mj.nq` for some arms.
+- **Frames**: end-effector frame is the URDF `ee_link` frame; Jacobians and
+  task-space quantities in `LOCAL_WORLD_ALIGNED` (world-aligned axes at the ee).
+  `World.ee_wrench()` returns the wrench **rotated into world-aligned axes**
+  (MuJoCo F/T sensors report in the body-fixed site frame — must be rotated by
+  site `xmat`). MuJoCo `mj_contactForce` uses a contact frame whose **X axis is
+  the normal** — document at every use site.
+- **Orientation error**: `rpy(R_des @ R.T)` as in the legacy script for ported
+  controllers (documented limitation: not a proper Lie-group error; revisit if
+  large-rotation tasks appear).
+- **Seeds**: every experiment script takes `--seed`; every random test fixes and
+  records its RNG seed.
+- **Wrench sign**: force *exerted by the robot on the environment* is positive in
+  task metrics. Verified by a Phase 1 static test (payload hanging at rest must
+  read +m·g in world −z on the sensor, sign-mapped accordingly).
+
 ## Key technical facts (verified / to verify early)
 
-- **MuJoCo cannot load DAE meshes** (STL/OBJ/MSH only). example-robot-data ships
-  *collision* meshes as STL → MuJoCo uses those for both collision and its own
-  rendering. Meshcat viewer keeps the pretty DAE visuals via the pinocchio path.
-  This split is a feature: physics never depends on visual meshes.
-- **MuJoCo compiles URDF directly** but produces no actuators; use the `mjSpec`
-  API (mujoco ≥3.2) to attach one `<motor>` per joint (ctrl = joint torque) and to
-  add scene elements (floor, wall, ee force sensor) around the compiled robot.
-- **Cross-engine consistency is testable**: at rest, pinocchio `g(q)` must equal
-  MuJoCo `qfrc_bias` (same URDF, same joint order). This is the anchor unit test
-  that catches 90% of integration mistakes (joint ordering, frame conventions,
-  inertia parsing).
-- Timing: physics dt 1–2 ms; control runs at its own dt (default 100 Hz to match
-  the current script; configurable to 1 kHz); viewer syncs ~real-time in
-  interactive mode, unconstrained headless.
-- Ubuntu 20.04 + Python 3.12 venv (`.venv`) is the target env. Headless rendering
-  (batch phase) uses EGL/osmesa — verify once in Phase 0, don't build on it before.
+- **MuJoCo does not resolve `package://` URIs** (all 14 UR5 mesh references use
+  them — verified). `models.py` must preprocess the URDF: rewrite
+  `package://example-robot-data/` to the absolute share path pinocchio uses.
+  Also verify visual DAE handling (MuJoCo can't load DAE): rely on
+  `discardvisual` default for URDF or strip `<visual>` elements in the same
+  preprocessing pass; MuJoCo uses the STL *collision* meshes.
+- **MuJoCo compiles URDF but produces no actuators** → attach one `<motor>` per
+  joint via `mjSpec`, with `forcerange` taken from URDF `<limit effort>`
+  (UR5: ≤150 N·m base, ≤28 N·m wrist). Unbounded motors flatter every controller
+  and would invalidate Phase 7 conclusions. Opt-out flag for idealized studies.
+- **Inertia processing**: compile with inertia balancing disabled
+  (`balanceinertia=false`); if the URDF inertias violate the triangle inequality,
+  that's a finding to document, not something the compiler should silently "fix"
+  (it would make pin and MuJoCo simulate different models).
+- **Legacy port traps (verified in `controllers/impedance_6dof.py`)**:
+  1. Plant is gravity-compensated (line 291) — see Decisions.
+  2. Lines 262/270: `(h - g - M @ Ji @ dJ) @ Ji @ v_desired` subtracts a 6-vector
+     from a 6×6 matrix — silent numpy broadcast, mathematically meaningless.
+     Benign in legacy only because `v_desired = 0` unless `dynamic_ref`. The port
+     must use the correct Coriolis-matrix form (`pin.computeCoriolisMatrix`) or
+     drop the term with documented justification.
+  3. `np.linalg.inv(J)` with no singularity handling → port uses damped
+     least-squares pseudoinverse with a manipulability guard.
+- **URDF `<dynamics>` damping/friction**: MuJoCo honors them (`qfrc_passive`),
+  `pin.aba` ignores them. UR5 has all zeros (verified) — the consistency test
+  asserts `qfrc_passive == 0` per robot; a nonzero case requires replicating
+  damping on the pinocchio side before that robot is supported.
+- Timing: physics dt 1–2 ms; control at its own dt (see Decisions); viewer syncs
+  ~real-time interactive, unconstrained headless.
+- Ubuntu 20.04 + Python 3.12 venv (`.venv`). Headless rendering (batch videos)
+  uses EGL — verify once in Phase 0, don't build on it before.
+
+## Interfaces (defined now to avoid Phase-4/6 rework)
+
+```python
+# state: canonical-order dataclass
+State:      q, dq, tau_applied, t                      # np arrays, canonical order
+Reference:  pose (SE3 or None), twist, accel,          # task-space targets
+            q_des, dq_des, ddq_des (or None),          # joint-space targets
+            wrench_des (or None)                       # force targets (contact tasks)
+LogSchema:  dict[str, np.ndarray]                      # fixed channel names + units,
+                                                       # defined once in Phase 2; shared
+                                                       # by runner, Task.metrics, Recorder
+
+Controller: __init__(ctrl_model, config_dataclass)     # model injected, params are data
+            reset(state0)
+            compute(state, ref, t, dt) -> tau          # TOTAL torque (incl. gravity comp)
+
+Task:       build_scene(spec)                          # owns ALL env geometry incl. floor
+            reference(t) -> Reference
+            metrics(log: LogSchema) -> dict
+
+World:      reset(q0); step(tau, n_substeps)
+            state() -> State
+            ee_wrench() -> np.ndarray                  # world-aligned, sign per Conventions
+            contacts() -> list                         # raw mj contacts (X-normal frame)
+            apply_external_wrench(frame, wrench)       # disturbance primitive (Phase 2)
+
+Viewer:     sync(state); close()
+```
+
+Config: every controller/task gets a small `@dataclass` config constructible from a
+plain dict, from Phase 2 onward. Phase 7's YAML layer only builds these dicts —
+no controller refactor at sweep time.
 
 ## Package layout
 
 ```
 icbench/
-  __init__.py
-  models.py            # registry: name -> URDF path/meshes; builds (pin.RobotWrapper, mjSpec robot)
-  sim/
-    __init__.py
-    world.py           # World: mjModel/mjData, step(tau), state(), contacts(), ee_wrench()
-    scene.py           # mjSpec helpers: floor, wall, ee site + force sensor, actuators
-  control/
-    __init__.py
-    base.py            # Controller ABC: reset(model_state), compute(state, t) -> tau
-    ctrl_model.py      # Pinocchio wrapper: M, nle, g, frame J/dJ, FK (control-side model;
-                       #   later: deliberately perturbed params for robustness studies)
-    impedance.py       # task-space impedance (ported variants 2/3/4 from legacy script)
-    joint_pd.py        # (phase 6) variants 1/5
-    admittance.py      # (phase 6)
-    computed_torque.py # (phase 6)
-  tasks/
-    __init__.py
-    base.py            # Task ABC: build_scene(spec), reference(t), metrics(log) -> dict
-    free_space.py      # regulation + moving reference (port of current demo behaviour)
-    wall_contact.py    # (phase 4) approach + press against wall, force target
-    surface_slide.py   # (phase 4) slide along surface at constant normal force
-  viz/
-    __init__.py
-    base.py            # Viewer ABC: sync(state), close()
-    mujoco_viewer.py   # mujoco.viewer.launch_passive
-    meshcat_viewer.py  # pin MeshcatVisualizer + the merge_geometries bundle patch
-  runner.py            # Experiment(robot, task, controller, viewer, dt...): interactive loop
-  recording.py         # (phase 5) Recorder -> timestamped run dir: config, npz, metrics, plots
-  analysis/            # (phases 7-8) sweep driver, aggregate reports, sysid estimators
-experiments/           # thin argparse scripts, one per study — read like today's demos
-tests/                 # pytest; consistency + unit tests, no GUI needed
+  models.py            # registry; URDF preprocessing (package:// → abs paths);
+                       #   builds pin RobotWrapper + mjSpec robot; joint index map
+  sim/world.py         # World (see interface); mujoco↔canonical remap lives here
+  sim/scene.py         # mjSpec helpers: actuators+forcerange, ee site + F/T sensor,
+                       #   floor/wall builders (called only by Tasks)
+  control/base.py      # Controller ABC
+  control/ctrl_model.py# pin wrapper: M, nle, g, coriolis matrix, frame J/dJ, FK
+  control/impedance.py # task-space impedance (reformulated variants 2/3/4)
+  control/joint_pd.py  # (phase 6) computed_torque.py, admittance.py
+  tasks/base.py        # Task ABC; free_space.py; (phase 4) wall_contact.py, surface_slide.py
+  viz/base.py          # mujoco_viewer.py; meshcat_viewer.py + meshcat_patch.py
+  runner.py            # Experiment loop; owns LogSchema assembly
+  recording.py         # (phase 5)
+  analysis/            # (phases 7-8)
+experiments/
+  _common.py           # shared argparse: --seed --viewer --record --duration
+  impedance_free_space.py, impedance_wall_contact.py, ...
+tests/
 ```
 
 ## Phases
 
-Commit at every checkbox. Each task lists its files; a task should be a few minutes
-of work. Run `./.venv/bin/pytest tests/ -q` before each commit from Phase 1 on.
+Commit at every checkbox. `./.venv/bin/pytest tests/ -q` before each commit from
+Phase 1 on. All spike findings and validation numbers go to **one** file:
+`docs/design/sim-framework/findings.md`.
 
-### Phase 0 — Scaffold (foundation, ~30 min)
+### Phase 0 — Scaffold
 
-- [ ] Add `mujoco==3.10.0` and `pytest` to `requirements.txt`; `pip install -r requirements.txt`
-- [ ] Create package skeleton: `icbench/__init__.py` (+ empty subpackage `__init__.py`s), `tests/`, `experiments/`
-- [ ] Smoke test `tests/test_smoke.py`: `import mujoco; import pinocchio; import icbench` passes
-- [ ] One-off spike (throwaway, do not commit code — commit findings to this plan):
-      compile the UR5 URDF with `mujoco.MjSpec.from_file`, print joint names/order,
-      confirm STL meshes resolve. Record any path quirks below in *Findings*.
+- [ ] `requirements.txt`: add `mujoco==3.10.0`, `pytest` (other deps already pinned); install
+- [ ] Package skeleton + `tests/test_smoke.py` (imports pass)
+- [ ] Spike (throwaway code, findings committed to findings.md): preprocess UR5 URDF
+      (package:// rewrite), compile via mjSpec, print joint names/order, confirm STL
+      meshes + `discardvisual` behavior, confirm EGL headless renders one frame
 
 ### Phase 1 — Models + World core
 
-- [ ] `icbench/models.py`: `load_robot(name) -> RobotBundle` — pin RobotWrapper
-      (visual DAE model) + URDF/mesh paths for MuJoCo, via example-robot-data.
-      Test: UR5 loads, `nq == 6`, joint names match between engines *in order*.
-- [ ] `icbench/sim/scene.py`: `build_spec(urdf_path, mesh_dir)` → mjSpec with robot,
-      floor plane, torque `<motor>` per joint, `ee` site + force/torque sensor.
-      Test: compiled model has 6 actuators; sensor exists.
-- [ ] `icbench/sim/world.py`: `World` — `reset(q0)`, `step(tau, n_substeps)`,
-      `state() -> (q, dq)`, `ee_wrench()`, `contacts()`.
-      Test: free fall matches gravity; torque input accelerates the expected joint.
-- [ ] **Consistency test** `tests/test_cross_engine.py`: for 20 random q,
-      `pin g(q) ≈ mujoco qfrc_bias(q, dq=0)` (tol 1e-8 after sign/order mapping);
-      pin `M(q)` ≈ mujoco `mj_fullM` (tol 1e-6). This test gates everything after it.
+- [ ] `models.py`: URDF preprocessing + `load_robot(name) -> RobotBundle` (pin wrapper,
+      preprocessed URDF path, joint index map). Test: UR5 loads; **explicit assertion
+      of the joint-order map itself**, not just quantities computed through it
+- [ ] `scene.py`: actuators with `forcerange` from URDF effort limits; `ee` site +
+      F/T sensor; **no floor here** — env geometry belongs to Tasks
+- [ ] `sim/world.py`: `World` per interface; remap lives here. Tests: free fall
+      (no floor!) matches gravity; torque on one joint accelerates it; static
+      payload test fixes wrench sign & frame (+m·g in world −z)
+- [ ] `apply_external_wrench()` primitive + test (constant wrench deflects ee as
+      predicted quasi-statically)
+- [ ] **Cross-engine tests** (`tests/test_cross_engine.py`, seeded RNG, relative
+      tol ~1e-6): (a) `pin g(q)` vs `qfrc_bias(q, 0)`; (b) `pin nle(q, dq)` vs
+      `qfrc_bias(q, dq)` at nonzero dq — catches Coriolis/order errors statics miss;
+      (c) `pin M(q)` vs `mj_fullM`; (d) `qfrc_passive == 0`
 
-### Phase 2 — Control layer + runner (free space parity with legacy demo)
+### Phase 2 — Control layer + runner (free-space)
 
-- [ ] `icbench/control/ctrl_model.py`: pin wrapper — `M, nle, g, J(frame), dJ, oMf`.
-      Test: values equal direct pin calls on the legacy script's pose.
-- [ ] `icbench/control/base.py`: `Controller` ABC (`reset`, `compute(state, t) -> tau`).
-- [ ] `icbench/control/impedance.py`: port legacy controllers 2/3/4 as
-      `TaskSpaceImpedance(variant=...)`. Test: given the legacy script's exact
-      state snapshot, tau matches the legacy computation (regression fixture).
-- [ ] `icbench/tasks/base.py` + `tasks/free_space.py`: fixed & sinusoidal reference
-      (port `dynamic_ref` logic), `metrics()` = tracking RMSE.
-- [ ] `icbench/runner.py`: `Experiment.run(duration)` loop — control dt vs physics
-      substeps, no viewer yet. Test: 2 s headless run completes, RMSE finite.
-- [ ] `experiments/impedance_free_space.py`: argparse (`--variant --duration --viewer none`),
-      prints metrics — behavioural sanity check vs legacy demo.
+- [ ] `ctrl_model.py`: pin wrapper incl. `coriolis(q, dq)` matrix. Test vs direct pin calls
+- [ ] `control/base.py` ABC + config dataclasses
+- [ ] `impedance.py`: **reformulated** variants 2/3/4 — explicit gravity/nle comp,
+      correct Coriolis-matrix term (replaces broadcast bug), damped-pinv J inverse.
+      Unit tests: multi-state golden fixtures **including dq≠0 states** for the
+      terms that are ports; documented derivation for the reformulated terms
+- [ ] **Closed-loop parity test**: replicate the legacy plant *exactly* in a test
+      harness (`pin.aba(q, dq, tau + g)`, explicit Euler, legacy dt) and assert the
+      ported controller class reproduces the legacy script's `q(t)` trajectory.
+      This validates the port; MuJoCo behavior is then validated separately for
+      stability (finite RMSE, no divergence) — it will differ, that's physics
+- [ ] `tasks/base.py` + `free_space.py` (fixed + sinusoidal reference; sine ee-force
+      disturbance via `apply_external_wrench` — parity with legacy `fe_amp` behavior)
+- [ ] `runner.py` + LogSchema (channel names/units fixed here, shared contract)
+- [ ] `experiments/_common.py` + `impedance_free_space.py` (`--variant --duration
+      --seed --viewer none`); README section: package vs legacy scripts
 
-### Phase 3 — Viewers (both, selectable)
+### Phase 3 — Viewers
 
-- [ ] `icbench/viz/base.py` + `mujoco_viewer.py` (`launch_passive`, real-time sync).
-- [ ] `meshcat_viewer.py`: move `_patch_meshcat_viewer_bundle()` out of the legacy
-      script into `icbench/viz/meshcat_patch.py`; legacy script imports it back from
-      there (single source of truth). Meshcat shows pin visual model synced to
-      MuJoCo state.
-- [ ] Wire `--viewer {none,mujoco,meshcat}` into runner + experiment scripts.
-      Manual check: same run looks identical in both viewers.
+- [ ] `viz/mujoco_viewer.py` (`launch_passive`, real-time sync) — authoritative
+- [ ] Move `_patch_meshcat_viewer_bundle()` from legacy script into
+      `icbench/viz/meshcat_patch.py` (legacy imports from there; **warn loudly**
+      when the bundle matches neither the broken nor the fixed pattern — silent
+      no-op only when already patched)
+- [ ] `viz/meshcat_viewer.py`: robot mirror (pin DAE visuals synced to MuJoCo state);
+      scene props mirrored best-effort from task metadata, explicitly not guaranteed
+- [ ] `--viewer {none,mujoco,meshcat}` wired through; manual visual check both paths
 
-### Phase 4 — Contact tasks (first real analysis payoff)
+### Phase 4 — Contact tasks
 
-- [ ] `scene.py`: `add_wall(spec, pose, friction)`; wall visible in both viewers
-      (meshcat: mirror as a box from task description).
-- [ ] `tasks/wall_contact.py`: approach → press to target normal force; metrics:
-      steady-state force error, overshoot, settling time.
-- [ ] `tasks/surface_slide.py`: constant-force slide; metrics: force RMSE along path.
-- [ ] `experiments/impedance_wall_contact.py`: run variants 2/3/4 against the wall,
-      matplotlib force/position plots at end (interactive-first).
-- [ ] Validation: impedance stiffness sweep shows expected force/penetration trend
-      (document numbers in `docs/design/sim-framework/findings.md`).
+- [ ] `scene.py`: `add_wall(spec, pose, friction)` (called from Task.build_scene)
+- [ ] `tasks/wall_contact.py`: approach → press to `wrench_des`; control dt 1 kHz;
+      metrics from **summed `mj_contactForce`** (ground truth; X-normal convention
+      documented at the use site) — F/T-sensor-based force feedback kept separate
+      as "what a real robot would measure" (bias-compensated) for admittance later
+- [ ] `tasks/surface_slide.py`: constant-normal-force slide; force RMSE along path
+- [ ] `experiments/impedance_wall_contact.py`: variants 2/3/4, force/position plots
+- [ ] Validation: stiffness sweep → force/penetration trend documented in findings.md;
+      README updated with contact experiments
 
-### Phase 5 — Recorder (enabler for batch work)
+### Phase 5 — Recorder
 
-- [ ] `icbench/recording.py`: opt-in `Recorder` — timestamped dir under `data/runs/`:
-      `config.json`, `timeseries.npz`, `metrics.json`, saved PNGs.
-- [ ] `--record` flag in experiment scripts. Legacy `data/` files untouched.
+- [ ] `recording.py`: opt-in, serializes the LogSchema + config dataclasses + metrics
+      to timestamped `data/runs/<ts>/`; add `data/runs/` to `.gitignore` (README
+      already bans committing data)
+- [ ] `--record` in `_common.py`
 
 ### Phase 6 — Controller zoo + comparison
 
-- [ ] Port joint-space PD (legacy 1/5) → `joint_pd.py`; add `admittance.py`
-      (position-based, needs measured ee wrench from World) and `computed_torque.py`.
+- [ ] `joint_pd.py` (legacy 1/5 reformulated), `computed_torque.py` — computed torque
+      **before** admittance (it's the admittance inner loop)
+- [ ] `admittance.py`: outer loop (wrench → motion reference) composed with inner
+      joint controller at 1 kHz; low-pass on measured wrench (cutoff well below
+      inner-loop bandwidth); uses F/T-sensor path, not contact ground truth
 - [ ] `experiments/controller_comparison.py`: same task × N controllers → metric
-      table + overlay plots.
+      table + overlay plots
 
 ### Phase 7 — Robustness & disturbance batch sweeps
 
-- [ ] `analysis/sweep.py`: config-driven (YAML) parameter grids — payload mass on
-      ee, wall friction, controller gains; headless parallel runs (verify EGL
-      headless rendering only if videos wanted); aggregate `metrics.parquet` + report.
-- [ ] Disturbance injection hooks in `World` (external wrench schedules — replaces
-      the legacy hardcoded sine force).
+- [ ] `analysis/sweep.py`: YAML → config-dataclass dicts (no controller changes);
+      grids over payload mass, wall friction, gains; headless parallel runs;
+      aggregate `metrics.parquet` + report
+- [ ] Disturbance *scheduling* (time-profiles over the existing Phase-2 wrench
+      primitive)
 
 ### Phase 8 — System ID / estimation testbed
 
-- [ ] `analysis/sysid/payload_estimation.py`: estimate ee payload mass from
-      joint torques + motion (RLS / least squares on regressor), sim = ground truth.
-      (Same problem family as the OKS lifter weight-estimation work — port lessons,
-      not code.)
+- [ ] `analysis/sysid/payload_estimation.py`: payload mass/inertia from joint
+      torques + motion (regressor least squares / RLS), sim ground truth from
+      Phase-7 payload machinery. (Same problem family as the OKS lifter
+      weight-estimation work — port lessons, not code)
 
-## Findings (append as work proceeds)
+## Findings
 
-- (Phase 0 spike results go here.)
+→ `docs/design/sim-framework/findings.md` (single location; Phase 0 spike results first).
 
 ## Non-goals (YAGNI, revisit only when hit)
 
 - ROS integration, real-robot interfaces
 - GPU/parallel sim (MJX), RL training
 - Upstream-PR compatibility of the package (legacy scripts stay compatible; the
-  package itself is our own)
+  package itself is ours)
+- Guaranteed meshcat scene fidelity (MuJoCo viewer is authoritative)

--- a/docs/design/sim-framework/plan.md
+++ b/docs/design/sim-framework/plan.md
@@ -7,8 +7,10 @@ config dataclasses from the start, per-controller control rates.*
 
 Part of the document set: [requirements.md](requirements.md) (what/why, REQ-IDs) →
 [design.md](design.md) (how, DD-IDs) → [verification.md](verification.md)
-(proof, TC-IDs + traceability matrix) → **plan.md** (when/order). Phase exits are
-gated by the L3/L4 test cases mapped to each phase in verification.md §3.
+(proof, TC-IDs + traceability matrix) → **plan.md** (when/order) →
+[execution/](execution/index.md) (dispatchable work packages WP-01..24 for
+subagents, with the dispatch protocol). Phase exits are gated by the L3/L4 test
+cases mapped to each phase in verification.md §3.
 
 ## Goal
 

--- a/docs/design/sim-framework/plan.md
+++ b/docs/design/sim-framework/plan.md
@@ -5,6 +5,11 @@ convention decision, URDF preprocessing task, typed interfaces, conventions
 section, closed-loop parity testing, external-wrench primitive moved to Phase 2,
 config dataclasses from the start, per-controller control rates.*
 
+Part of the document set: [requirements.md](requirements.md) (what/why, REQ-IDs) →
+[design.md](design.md) (how, DD-IDs) → [verification.md](verification.md)
+(proof, TC-IDs + traceability matrix) → **plan.md** (when/order). Phase exits are
+gated by the L3/L4 test cases mapped to each phase in verification.md §3.
+
 ## Goal
 
 Evolve this repo from two standalone demo scripts into an **experimental simulation

--- a/docs/design/sim-framework/plan.md
+++ b/docs/design/sim-framework/plan.md
@@ -1,0 +1,181 @@
+# Experimental Simulation Package — Implementation Plan
+
+## Goal
+
+Evolve this repo from two standalone demo scripts into an **experimental simulation
+package** for robot-arm control analysis. Impedance control becomes one test among
+many. Target capabilities (in build order): real contact physics, a controller zoo
+with comparisons, robustness/disturbance batch sweeps, and system-ID/estimation
+testbeds.
+
+## Decisions (agreed 2026-07-17)
+
+| Topic | Decision |
+|---|---|
+| Physics backend | **MuJoCo** (`mujoco==3.10.0`, pip) simulates the world; **Pinocchio** stays for control-side model terms (M, C, g, Jacobians) |
+| Model source | One shared URDF (example-robot-data) loaded into *both* engines → no model mismatch between sim and controller. UR5 first; any example-robot-data arm pluggable by name |
+| Viewer | Both backends, selectable per run: MuJoCo native viewer *and* meshcat (browser). Meshcat reuses the `merge_geometries` bundle patch |
+| Consumption | Interactive-first (live viewer + matplotlib at end). `Recorder` is optional, needed later for batch sweeps |
+| First analysis | Contact interaction tasks (wall contact / surface slide) |
+| Repo shape | Python package `icbench/` + thin runnable scripts in `experiments/`. Legacy `controllers/*.py` stay untouched and working |
+
+## Key technical facts (verified / to verify early)
+
+- **MuJoCo cannot load DAE meshes** (STL/OBJ/MSH only). example-robot-data ships
+  *collision* meshes as STL → MuJoCo uses those for both collision and its own
+  rendering. Meshcat viewer keeps the pretty DAE visuals via the pinocchio path.
+  This split is a feature: physics never depends on visual meshes.
+- **MuJoCo compiles URDF directly** but produces no actuators; use the `mjSpec`
+  API (mujoco ≥3.2) to attach one `<motor>` per joint (ctrl = joint torque) and to
+  add scene elements (floor, wall, ee force sensor) around the compiled robot.
+- **Cross-engine consistency is testable**: at rest, pinocchio `g(q)` must equal
+  MuJoCo `qfrc_bias` (same URDF, same joint order). This is the anchor unit test
+  that catches 90% of integration mistakes (joint ordering, frame conventions,
+  inertia parsing).
+- Timing: physics dt 1–2 ms; control runs at its own dt (default 100 Hz to match
+  the current script; configurable to 1 kHz); viewer syncs ~real-time in
+  interactive mode, unconstrained headless.
+- Ubuntu 20.04 + Python 3.12 venv (`.venv`) is the target env. Headless rendering
+  (batch phase) uses EGL/osmesa — verify once in Phase 0, don't build on it before.
+
+## Package layout
+
+```
+icbench/
+  __init__.py
+  models.py            # registry: name -> URDF path/meshes; builds (pin.RobotWrapper, mjSpec robot)
+  sim/
+    __init__.py
+    world.py           # World: mjModel/mjData, step(tau), state(), contacts(), ee_wrench()
+    scene.py           # mjSpec helpers: floor, wall, ee site + force sensor, actuators
+  control/
+    __init__.py
+    base.py            # Controller ABC: reset(model_state), compute(state, t) -> tau
+    ctrl_model.py      # Pinocchio wrapper: M, nle, g, frame J/dJ, FK (control-side model;
+                       #   later: deliberately perturbed params for robustness studies)
+    impedance.py       # task-space impedance (ported variants 2/3/4 from legacy script)
+    joint_pd.py        # (phase 6) variants 1/5
+    admittance.py      # (phase 6)
+    computed_torque.py # (phase 6)
+  tasks/
+    __init__.py
+    base.py            # Task ABC: build_scene(spec), reference(t), metrics(log) -> dict
+    free_space.py      # regulation + moving reference (port of current demo behaviour)
+    wall_contact.py    # (phase 4) approach + press against wall, force target
+    surface_slide.py   # (phase 4) slide along surface at constant normal force
+  viz/
+    __init__.py
+    base.py            # Viewer ABC: sync(state), close()
+    mujoco_viewer.py   # mujoco.viewer.launch_passive
+    meshcat_viewer.py  # pin MeshcatVisualizer + the merge_geometries bundle patch
+  runner.py            # Experiment(robot, task, controller, viewer, dt...): interactive loop
+  recording.py         # (phase 5) Recorder -> timestamped run dir: config, npz, metrics, plots
+  analysis/            # (phases 7-8) sweep driver, aggregate reports, sysid estimators
+experiments/           # thin argparse scripts, one per study — read like today's demos
+tests/                 # pytest; consistency + unit tests, no GUI needed
+```
+
+## Phases
+
+Commit at every checkbox. Each task lists its files; a task should be a few minutes
+of work. Run `./.venv/bin/pytest tests/ -q` before each commit from Phase 1 on.
+
+### Phase 0 — Scaffold (foundation, ~30 min)
+
+- [ ] Add `mujoco==3.10.0` and `pytest` to `requirements.txt`; `pip install -r requirements.txt`
+- [ ] Create package skeleton: `icbench/__init__.py` (+ empty subpackage `__init__.py`s), `tests/`, `experiments/`
+- [ ] Smoke test `tests/test_smoke.py`: `import mujoco; import pinocchio; import icbench` passes
+- [ ] One-off spike (throwaway, do not commit code — commit findings to this plan):
+      compile the UR5 URDF with `mujoco.MjSpec.from_file`, print joint names/order,
+      confirm STL meshes resolve. Record any path quirks below in *Findings*.
+
+### Phase 1 — Models + World core
+
+- [ ] `icbench/models.py`: `load_robot(name) -> RobotBundle` — pin RobotWrapper
+      (visual DAE model) + URDF/mesh paths for MuJoCo, via example-robot-data.
+      Test: UR5 loads, `nq == 6`, joint names match between engines *in order*.
+- [ ] `icbench/sim/scene.py`: `build_spec(urdf_path, mesh_dir)` → mjSpec with robot,
+      floor plane, torque `<motor>` per joint, `ee` site + force/torque sensor.
+      Test: compiled model has 6 actuators; sensor exists.
+- [ ] `icbench/sim/world.py`: `World` — `reset(q0)`, `step(tau, n_substeps)`,
+      `state() -> (q, dq)`, `ee_wrench()`, `contacts()`.
+      Test: free fall matches gravity; torque input accelerates the expected joint.
+- [ ] **Consistency test** `tests/test_cross_engine.py`: for 20 random q,
+      `pin g(q) ≈ mujoco qfrc_bias(q, dq=0)` (tol 1e-8 after sign/order mapping);
+      pin `M(q)` ≈ mujoco `mj_fullM` (tol 1e-6). This test gates everything after it.
+
+### Phase 2 — Control layer + runner (free space parity with legacy demo)
+
+- [ ] `icbench/control/ctrl_model.py`: pin wrapper — `M, nle, g, J(frame), dJ, oMf`.
+      Test: values equal direct pin calls on the legacy script's pose.
+- [ ] `icbench/control/base.py`: `Controller` ABC (`reset`, `compute(state, t) -> tau`).
+- [ ] `icbench/control/impedance.py`: port legacy controllers 2/3/4 as
+      `TaskSpaceImpedance(variant=...)`. Test: given the legacy script's exact
+      state snapshot, tau matches the legacy computation (regression fixture).
+- [ ] `icbench/tasks/base.py` + `tasks/free_space.py`: fixed & sinusoidal reference
+      (port `dynamic_ref` logic), `metrics()` = tracking RMSE.
+- [ ] `icbench/runner.py`: `Experiment.run(duration)` loop — control dt vs physics
+      substeps, no viewer yet. Test: 2 s headless run completes, RMSE finite.
+- [ ] `experiments/impedance_free_space.py`: argparse (`--variant --duration --viewer none`),
+      prints metrics — behavioural sanity check vs legacy demo.
+
+### Phase 3 — Viewers (both, selectable)
+
+- [ ] `icbench/viz/base.py` + `mujoco_viewer.py` (`launch_passive`, real-time sync).
+- [ ] `meshcat_viewer.py`: move `_patch_meshcat_viewer_bundle()` out of the legacy
+      script into `icbench/viz/meshcat_patch.py`; legacy script imports it back from
+      there (single source of truth). Meshcat shows pin visual model synced to
+      MuJoCo state.
+- [ ] Wire `--viewer {none,mujoco,meshcat}` into runner + experiment scripts.
+      Manual check: same run looks identical in both viewers.
+
+### Phase 4 — Contact tasks (first real analysis payoff)
+
+- [ ] `scene.py`: `add_wall(spec, pose, friction)`; wall visible in both viewers
+      (meshcat: mirror as a box from task description).
+- [ ] `tasks/wall_contact.py`: approach → press to target normal force; metrics:
+      steady-state force error, overshoot, settling time.
+- [ ] `tasks/surface_slide.py`: constant-force slide; metrics: force RMSE along path.
+- [ ] `experiments/impedance_wall_contact.py`: run variants 2/3/4 against the wall,
+      matplotlib force/position plots at end (interactive-first).
+- [ ] Validation: impedance stiffness sweep shows expected force/penetration trend
+      (document numbers in `docs/design/sim-framework/findings.md`).
+
+### Phase 5 — Recorder (enabler for batch work)
+
+- [ ] `icbench/recording.py`: opt-in `Recorder` — timestamped dir under `data/runs/`:
+      `config.json`, `timeseries.npz`, `metrics.json`, saved PNGs.
+- [ ] `--record` flag in experiment scripts. Legacy `data/` files untouched.
+
+### Phase 6 — Controller zoo + comparison
+
+- [ ] Port joint-space PD (legacy 1/5) → `joint_pd.py`; add `admittance.py`
+      (position-based, needs measured ee wrench from World) and `computed_torque.py`.
+- [ ] `experiments/controller_comparison.py`: same task × N controllers → metric
+      table + overlay plots.
+
+### Phase 7 — Robustness & disturbance batch sweeps
+
+- [ ] `analysis/sweep.py`: config-driven (YAML) parameter grids — payload mass on
+      ee, wall friction, controller gains; headless parallel runs (verify EGL
+      headless rendering only if videos wanted); aggregate `metrics.parquet` + report.
+- [ ] Disturbance injection hooks in `World` (external wrench schedules — replaces
+      the legacy hardcoded sine force).
+
+### Phase 8 — System ID / estimation testbed
+
+- [ ] `analysis/sysid/payload_estimation.py`: estimate ee payload mass from
+      joint torques + motion (RLS / least squares on regressor), sim = ground truth.
+      (Same problem family as the OKS lifter weight-estimation work — port lessons,
+      not code.)
+
+## Findings (append as work proceeds)
+
+- (Phase 0 spike results go here.)
+
+## Non-goals (YAGNI, revisit only when hit)
+
+- ROS integration, real-robot interfaces
+- GPU/parallel sim (MJX), RL training
+- Upstream-PR compatibility of the package (legacy scripts stay compatible; the
+  package itself is our own)

--- a/docs/design/sim-framework/requirements.md
+++ b/docs/design/sim-framework/requirements.md
@@ -8,6 +8,7 @@ Rev 1 — 2026-07-17. Part of the document set:
 | [design.md](design.md) | How it is built |
 | [verification.md](verification.md) | How we prove it (test cases + traceability) |
 | [plan.md](plan.md) | In what order (phased implementation schedule) |
+| [execution/](execution/index.md) | Who does it (self-contained work packages WP-01..24 dispatchable to subagents; REQ→WP map in the index) |
 
 ## 1. Purpose & Scope
 

--- a/docs/design/sim-framework/requirements.md
+++ b/docs/design/sim-framework/requirements.md
@@ -1,0 +1,149 @@
+# System Requirements Specification — Experimental Simulation Package (`icbench`)
+
+Rev 1 — 2026-07-17. Part of the document set:
+
+| Doc | Answers |
+|---|---|
+| **requirements.md** (this) | What must the system do, and why |
+| [design.md](design.md) | How it is built |
+| [verification.md](verification.md) | How we prove it (test cases + traceability) |
+| [plan.md](plan.md) | In what order (phased implementation schedule) |
+
+## 1. Purpose & Scope
+
+An experimental simulation package for robot-arm control analysis: contact-capable
+physics (MuJoCo) with model-based control (Pinocchio), controller comparison,
+robustness sweeps, and estimation testbeds. Single primary user (research
+engineer). Out of scope: ROS integration, real-robot interfaces, GPU/parallel
+simulation, RL training.
+
+**Verification methods** — T: automated test, D: demonstration (manual, scripted
+steps), A: analysis (derivation/measurement documented in findings.md),
+I: inspection (code/docs review).
+**Priority** — M: must, S: should, C: could (MoSCoW).
+
+## 2. Stakeholder Needs
+
+| ID | Need |
+|---|---|
+| SN-1 | Evaluate interaction controllers (impedance & friends) against realistic contact physics, not synthetic force injections |
+| SN-2 | Compare multiple controllers on identical tasks with quantitative metrics |
+| SN-3 | Assess robustness to parameter uncertainty and disturbances via batch sweeps |
+| SN-4 | Ground-truth testbed for estimation / system-ID algorithms (payload estimation first) |
+| SN-5 | Interactive visual inspection during runs; plots for analysis afterwards |
+| SN-6 | Results reproducible; codebase maintainable by one engineer |
+| SN-7 | Legacy demo scripts keep working (upstream fork heritage) |
+
+## 3. System Context
+
+```mermaid
+flowchart LR
+    U[Researcher] -->|CLI args / config| E[experiments/*.py]
+    E --> R[icbench runner]
+    R --> W[World MuJoCo]
+    R --> C[Controller Pinocchio model]
+    R --> V[Viewer: MuJoCo / meshcat / none]
+    R --> L[LogSchema] --> P[Plots / metrics]
+    L -.opt-in.-> REC[Recorder → data/runs/]
+    ERD[example-robot-data URDF/meshes] --> W
+    ERD --> C
+```
+
+System boundary: everything under `icbench/` + `experiments/`. External: MuJoCo,
+Pinocchio, example-robot-data, meshcat, matplotlib.
+
+## 4. Functional Requirements
+
+### 4.1 Modeling (MDL)
+
+| ID | Requirement | Rationale | Pri | Ver | Trace |
+|---|---|---|---|---|---|
+| REQ-MDL-001 | The system shall load a robot by name from example-robot-data, with UR5 as the reference model. | Pluggable robots | M | T | SN-1..4 |
+| REQ-MDL-002 | The system shall load the *same* URDF into both engines, preprocessing it for MuJoCo (resolve `package://` URIs; ensure DAE visuals are discarded/stripped; inertia balancing disabled). | No sim-vs-controller model mismatch | M | T | SN-1, SN-6 |
+| REQ-MDL-003 | The system shall construct an explicit MuJoCo↔canonical joint index map and state converters, never assuming identity ordering. | pin.nq ≠ mj.nq possible; ordering is a classic silent bug | M | T | SN-6 |
+| REQ-MDL-004 | The system shall reject (with a clear error) robots violating supported assumptions: pin/mj state dimension mismatch without a converter, or nonzero URDF `<dynamics>` not replicated on the pinocchio side. | Fail loudly, not wrongly | M | T | SN-6 |
+| REQ-MDL-005 | The system shall attach one torque actuator per joint with `forcerange` from URDF effort limits, with a documented opt-out for idealized studies. | Unbounded torque flatters controllers, invalidates sweeps | M | T | SN-2, SN-3 |
+
+### 4.2 Simulation (SIM)
+
+| ID | Requirement | Rationale | Pri | Ver | Trace |
+|---|---|---|---|---|---|
+| REQ-SIM-001 | The World shall step MuJoCo physics at dt_phys (1–2 ms) with the control period an integer multiple (per-controller/task property). | Stability of stiff controllers/contact | M | T | SN-1 |
+| REQ-SIM-002 | The World shall expose canonical-order `State (q, dq, tau_applied, t)`. | Single convention at component boundaries | M | T | SN-6 |
+| REQ-SIM-003 | The World shall report the ee wrench rotated into world-aligned axes with the documented sign convention (robot-on-environment positive). | MuJoCo F/T sensors report in body-fixed site frame | M | T | SN-1 |
+| REQ-SIM-004 | The World shall enumerate contacts with forces (ground truth), documenting MuJoCo's X-axis-is-normal contact frame at every use site. | Contact metrics need truth data | M | T | SN-1 |
+| REQ-SIM-005 | The World shall support external wrench injection at a named frame, usable from Phase 2 (free-space disturbance parity) and schedulable later. | Legacy sine disturbance; robustness studies | M | T | SN-1, SN-3 |
+| REQ-SIM-006 | The plant shall be real: gravity applied by MuJoCo, no hidden compensation anywhere in World. | Legacy plant secretly cancels g; must not be replicated | M | T/I | SN-1 |
+| REQ-SIM-007 | A simulation run shall be deterministic given (config, seed). | Reproducibility, regression testing | M | T | SN-6 |
+
+### 4.3 Control (CTL)
+
+| ID | Requirement | Rationale | Pri | Ver | Trace |
+|---|---|---|---|---|---|
+| REQ-CTL-001 | Controllers shall implement `compute(state, ref, t, dt) -> tau` returning **total** torque including their own gravity/nle compensation. | Gravity convention (see design DD-2) | M | T | SN-1, SN-2 |
+| REQ-CTL-002 | A control-side model (`ctrl_model`) shall provide M, nle, g, Coriolis matrix, frame J/dJ, FK — canonical order, LOCAL_WORLD_ALIGNED frames. | Model-based control terms | M | T | SN-1 |
+| REQ-CTL-003 | Task-space impedance variants (legacy 2/3/4) shall be provided as *reformulated* controllers: explicit gravity/nle comp; correct Coriolis-matrix term replacing the legacy vector−matrix broadcast bug; derivations documented. | Legacy code has verified math bugs | M | T/A | SN-1, SN-7 |
+| REQ-CTL-004 | Each controller shall declare its control rate (legacy variant 2: 1 kHz; contact tasks: 1 kHz default). | Variant 2 designed at wn=250 rad/s | M | T | SN-1 |
+| REQ-CTL-005 | Task-space inverses shall be singularity-robust (damped least squares + manipulability guard). | Legacy `inv(J)` unguarded | M | T | SN-1 |
+| REQ-CTL-006 | The controller zoo shall include joint PD, computed torque, and admittance; admittance as an outer loop over an inner tracking controller with low-pass-filtered measured wrench. | Comparison studies; admittance needs inner loop | S | T | SN-2 |
+| REQ-CTL-007 | Every controller/task shall take a `@dataclass` config constructible from a plain dict. | Sweep layer must not force refactors | M | T | SN-3, SN-6 |
+
+### 4.4 Tasks (TSK)
+
+| ID | Requirement | Rationale | Pri | Ver | Trace |
+|---|---|---|---|---|---|
+| REQ-TSK-001 | Tasks shall own all environment geometry (incl. floor), reference generation (typed `Reference`: pose/twist/accel, joint targets, wrench target), and metrics from the LogSchema. | Clean separation; no phantom floor contacts | M | T/I | SN-1, SN-2 |
+| REQ-TSK-002 | A free-space task shall provide regulation + sinusoidal tracking + sine ee-force disturbance (legacy parity). | Baseline & port validation | M | T | SN-7 |
+| REQ-TSK-003 | A wall-contact task shall press to a target normal force; metrics: steady-state force error, overshoot, settling time (from contact ground truth). | First contact analysis | M | T | SN-1 |
+| REQ-TSK-004 | A surface-slide task shall track constant normal force along a path; metric: force RMSE. | Second contact analysis | S | T | SN-1 |
+
+### 4.5 Visualization (VIZ)
+
+| ID | Requirement | Rationale | Pri | Ver | Trace |
+|---|---|---|---|---|---|
+| REQ-VIZ-001 | The MuJoCo native viewer shall be available as the authoritative view (true physics scene), near-real-time in interactive mode. | Trustworthy inspection | M | D | SN-5 |
+| REQ-VIZ-002 | A meshcat viewer shall be available as an optional robot mirror (DAE visuals; scene props best-effort). | User preference; remote/browser viewing | S | D | SN-5 |
+| REQ-VIZ-003 | Runs shall be executable headless (`--viewer none`). | Batch sweeps | M | T | SN-3 |
+| REQ-VIZ-004 | The meshcat viewer-bundle patch shall live in one module, warn loudly when the bundle matches neither known pattern, and be reused by the legacy script. | Silent no-op caused a long debugging session | M | T/I | SN-6, SN-7 |
+
+### 4.6 Experiments & Recording (EXP / REC)
+
+| ID | Requirement | Rationale | Pri | Ver | Trace |
+|---|---|---|---|---|---|
+| REQ-EXP-001 | A runner shall compose robot+task+controller+viewer, run for a duration, and assemble the fixed-schema log (channel names/units defined once). | Shared contract runner↔metrics↔recorder | M | T | SN-2, SN-6 |
+| REQ-EXP-002 | Experiment scripts shall be thin, sharing argparse conventions (`--seed --viewer --record --duration`) via a common helper. | Prevent copy-paste drift | M | I | SN-6 |
+| REQ-EXP-003 | Interactive runs shall end with matplotlib plots of task-relevant channels. | Interactive-first consumption | M | D | SN-5 |
+| REQ-REC-001 | An opt-in Recorder shall write a timestamped run dir: config snapshot, timeseries, metrics, plots. | Batch analysis, reproducibility | M | T | SN-3, SN-6 |
+| REQ-REC-002 | Run outputs shall be excluded from version control (`data/runs/` gitignored). | Repo policy bans data files | M | I | SN-7 |
+
+### 4.7 Analysis (ANA)
+
+| ID | Requirement | Rationale | Pri | Ver | Trace |
+|---|---|---|---|---|---|
+| REQ-ANA-001 | A sweep driver shall run YAML-defined parameter grids (payload, friction, gains) headless, in parallel, aggregating metrics into a single artifact + report. | Robustness studies | S | T | SN-3 |
+| REQ-ANA-002 | Disturbance schedules (time profiles over the REQ-SIM-005 primitive) shall be sweepable parameters. | Disturbance rejection studies | S | T | SN-3 |
+| REQ-ANA-003 | A payload-estimation testbed shall estimate ee payload mass/inertia from joint torques + motion, reporting error vs sim ground truth. | SysID need | S | T | SN-4 |
+
+## 5. Non-Functional Requirements
+
+| ID | Requirement | Pri | Ver | Trace |
+|---|---|---|---|---|
+| REQ-NFR-001 | Cross-engine model consistency: pin {g(q), nle(q,dq), M(q)} vs MuJoCo equivalents agree within relative tolerance 1e-6 over seeded random states. | M | T | SN-1, SN-6 |
+| REQ-NFR-002 | A 10 s free-space simulation (headless, no recording) completes in ≤ 10 s wall-clock on the dev machine (≥ 1× real-time). Measured and recorded in findings.md. | S | A | SN-3 |
+| REQ-NFR-003 | Same (config, seed) ⇒ identical LogSchema arrays across two runs (bitwise; documented relaxation to tolerance if a nondeterminism source is found and justified). | M | T | SN-6 |
+| REQ-NFR-004 | Runs on Ubuntu 20.04 / Python 3.12 venv with pip-only pinned dependencies (`requirements.txt`). | M | I | SN-6 |
+| REQ-NFR-005 | Every phase lands with green pytest; core physics/controller math covered by unit + integration tests; conventions documented in plan.md §Conventions. | M | T/I | SN-6 |
+| REQ-NFR-006 | Legacy scripts (`controllers/*.py`) remain functional and behaviorally unchanged. | M | T/D | SN-7 |
+| REQ-NFR-007 | Adding a new experiment requires only a new script + config (no core changes); adding a controller requires only a new Controller subclass + config dataclass. | S | I/D | SN-2, SN-6 |
+
+## 6. Assumptions & Constraints
+
+- A-1: example-robot-data UR5 URDF inertias are taken as-is (known to be rough);
+  cross-engine consistency is about *both engines agreeing*, not matching the real
+  robot.
+- A-2: MuJoCo's soft-contact model (default solref/solimp) is acceptable contact
+  truth for controller comparison; absolute contact fidelity vs reality is out of
+  scope.
+- A-3: Single developer; no CI server — pytest-before-commit is the gate
+  (REQ-NFR-005).
+- C-1: No internet access assumed at runtime (models vendored via pip packages).

--- a/docs/design/sim-framework/verification.md
+++ b/docs/design/sim-framework/verification.md
@@ -1,0 +1,262 @@
+# Verification & Validation Plan — Experimental Simulation Package (`icbench`)
+
+Rev 1 — 2026-07-17. Verifies [requirements.md](requirements.md) against
+[design.md](design.md); executed per the [plan.md](plan.md) schedule.
+
+## 1. Strategy
+
+**Levels** (V-model right side):
+
+| Level | What | How | Gate |
+|---|---|---|---|
+| L1 Unit | One function/class in isolation | pytest, no GUI | every commit |
+| L2 Integration | Cross-engine consistency; component pairs | pytest, seeded | every commit from Phase 1 |
+| L3 System | Closed-loop runs end-to-end | pytest (headless) | phase exit |
+| L4 Validation | "Does the physics/controller behave like physics/controllers" | scripted demonstrations + analysis in findings.md | phase exit |
+
+**Principles**
+
+- Every automated test with randomness uses a fixed, recorded seed.
+- Tolerances: cross-engine comparisons *relative* 1e-6 (REQ-NFR-001);
+  closed-loop parity tolerances stated per test and justified.
+- Manual demonstrations (viewers) have written step lists and expected
+  observations — subjective "looks right" is not a pass criterion; specific
+  observables are.
+- A failing L2 cross-engine test blocks all downstream work (it means the two
+  engines disagree about the model — nothing built on top is meaningful).
+
+## 2. Test Case Specifications
+
+IDs: `TC-<area>-<nnn>`. Each maps to requirements (→ §3 traceability).
+
+### Cross-engine (the anchor set)
+
+**TC-CE-001 — Gravity vector equivalence** (L2)
+For 20 seeded random q within joint limits: `pin.g(q)` vs MuJoCo
+`qfrc_bias(q, dq=0)` mapped to canonical order; rel. tol 1e-6.
+*Verifies REQ-NFR-001, REQ-MDL-002/003.*
+
+**TC-CE-002 — Bias-force equivalence at speed** (L2)
+Same states with seeded random dq ≠ 0: `pin.nle(q,dq)` vs `qfrc_bias(q,dq)`.
+Catches Coriolis/ordering errors invisible at rest.
+*Verifies REQ-NFR-001.*
+
+**TC-CE-003 — Mass matrix equivalence** (L2)
+`pin.M(q)` vs `mj_fullM`; symmetric, rel. tol 1e-6.
+*Verifies REQ-NFR-001.*
+
+**TC-CE-004 — No passive forces** (L2)
+`qfrc_passive == 0` for the loaded robot (URDF damping/friction all zero, and no
+compiler-injected passive terms). *Verifies REQ-MDL-004.*
+
+### Modeling
+
+**TC-MDL-001 — Robot loads** (L1) UR5 via `load_robot("ur5")`: nq=nv=6, meshes
+resolved (no missing-file errors), preprocessed URDF has no `package://`.
+*Verifies REQ-MDL-001/002.*
+
+**TC-MDL-002 — Joint map asserted directly** (L1) The mj↔canonical map is
+verified by joint *names* on both sides, not through derived quantities;
+round-trip q→mj→canonical is identity. *Verifies REQ-MDL-003.*
+
+**TC-MDL-003 — Unsupported robot rejected** (L1) A synthetic URDF with nonzero
+joint damping raises a clear error naming the joint. *Verifies REQ-MDL-004.*
+
+**TC-MDL-004 — Actuator force range** (L1) Compiled model has 6 motors;
+`forcerange` equals URDF effort limits; opt-out flag removes clamping.
+*Verifies REQ-MDL-005.*
+
+### Simulation / World
+
+**TC-SIM-001 — Free fall** (L2) Empty scene (no floor — DD-8), zero torque:
+joint accelerations at t=0 equal `M⁻¹·(−g_bias)` from pinocchio; energy drift
+over 1 s within integrator expectations (documented bound).
+*Verifies REQ-SIM-001/006, REQ-TSK-001 (no phantom floor).*
+
+**TC-SIM-002 — Torque causality** (L2) Constant torque on one joint (others
+gravity-held via pin g(q) feedforward): that joint accelerates in the expected
+direction, others stay bounded. *Verifies REQ-SIM-001/002.*
+
+**TC-SIM-003 — Wrench frame & sign** (L2) Static known payload m attached at ee,
+arm at rest (position-held): `ee_wrench()` reads +m·g in world −z within 2%;
+sensor-frame rotation verified at a second, rotated pose.
+*Verifies REQ-SIM-003.*
+
+**TC-SIM-004 — External wrench primitive** (L2) Constant world-frame force at ee
+deflects the gravity-compensated arm in the force direction; removing it returns
+near the original pose. *Verifies REQ-SIM-005.*
+
+**TC-SIM-005 — Determinism** (L3) Two runs, same config+seed: LogSchema arrays
+bitwise identical. *Verifies REQ-SIM-007, REQ-NFR-003.*
+
+### Control
+
+**TC-CTL-001 — Gravity hold** (L3) Each controller variant, regulation reference
+at the legacy home pose, no disturbance: ee position error stays < 5 mm for 5 s
+(controller self-compensates gravity — the DD-2 acid test; a legacy-copied
+controller sags and fails this immediately). *Verifies REQ-CTL-001/003.*
+
+**TC-CTL-002 — CtrlModel correctness** (L1) M, nle, g, J, dJ, FK against direct
+pinocchio calls at fixture states. Coriolis matrix property:
+`Ṁ − 2C` skew-symmetric at seeded states. *Verifies REQ-CTL-002.*
+
+**TC-CTL-003 — Golden fixtures** (L1) Ported (unchanged) controller terms match
+recorded legacy values at ≥3 states including dq≠0; reformulated terms match
+their documented derivation computed independently in the test.
+*Verifies REQ-CTL-003.*
+
+**TC-CTL-004 — Legacy closed-loop parity** (L3) Test harness replicating the
+legacy plant exactly (`pin.aba(q,dq,τ+g)`, explicit Euler, legacy dt): ported
+variant-4 controller minus its added g-compensation reproduces the legacy
+script's q(t) over 2 s within 1e-9 (same math, same integrator).
+*Verifies REQ-CTL-003, REQ-NFR-006 (port faithfulness).*
+
+**TC-CTL-005 — Singularity robustness** (L1) `damped_pinv` at a singular J:
+bounded output, smooth λ transition; manipulability guard activates.
+*Verifies REQ-CTL-005.*
+
+**TC-CTL-006 — Control-rate declaration** (L1) Variant 2 config defaults to
+1 kHz; runner rejects non-integer dt_ctrl/dt_phys. *Verifies REQ-CTL-004,
+REQ-SIM-001.*
+
+**TC-CTL-007 — Config round-trip** (L1) Every controller/task config:
+dict → dataclass → dict is lossless. *Verifies REQ-CTL-007.*
+
+**TC-CTL-008 — Admittance composition** (L3, Phase 6) Admittance over inner
+computed-torque against the wall task: contact force converges to target ±10%
+without oscillation growth; wrench low-pass verified active (spectrum check on
+logged wrench). *Verifies REQ-CTL-006.*
+
+### Tasks & System
+
+**TC-SYS-001 — Free-space tracking** (L3) Variant 3/4 on sinusoidal reference
+(no disturbance): finite RMSE below a recorded baseline; no NaN; run completes.
+Baseline captured once, asserted as non-regression afterwards.
+*Verifies REQ-TSK-002, REQ-EXP-001.*
+
+**TC-SYS-002 — Free-space disturbance parity** (L3) Sine ee-force via
+REQ-SIM-005 primitive: response qualitatively matches legacy demo (force/error
+phase relationship; documented comparison in findings.md).
+*Verifies REQ-TSK-002, REQ-SIM-005.*
+
+**TC-SYS-003 — Wall contact metrics** (L3) Variant 4 pressing to 20 N target:
+steady-state |error| < 2 N, metrics dict contains the three specified fields,
+computed from `ee_wrench_contact` (ground truth channel).
+*Verifies REQ-TSK-003, REQ-SIM-004.*
+
+**TC-SYS-004 — Surface slide** (L3) Constant-force slide: force RMSE finite and
+below recorded baseline; path completed. *Verifies REQ-TSK-004.*
+
+### Validation (L4 — physics behaves like physics)
+
+**TC-VAL-001 — Stiffness/penetration trend** Impedance stiffness sweep against
+the wall: steady-state penetration decreases monotonically with Kd; steady-state
+force error trend documented. Numbers in findings.md.
+*Validates REQ-TSK-003, A-2.*
+
+**TC-VAL-002 — Real-time factor** 10 s free-space headless run timed; RTF ≥ 1
+recorded in findings.md. *Verifies REQ-NFR-002 (A).*
+
+**TC-VAL-003 — Effort-limit effect** Same task with/without force ranges:
+saturated case shows clipped tau in log; documented.
+*Validates REQ-MDL-005.*
+
+### Visualization & Experiments
+
+**TC-VIZ-001 — MuJoCo viewer demo** (D) Scripted: run wall-contact experiment
+`--viewer mujoco`; observe arm, wall, contact — no missing geometry; sim-time/
+wall-time ratio displayed ≈ 1. *Verifies REQ-VIZ-001.*
+
+**TC-VIZ-002 — Meshcat mirror demo** (D) Same run `--viewer meshcat`: full-mesh
+robot (regression check vs the merge_geometries bug: shoulder/wrist housings
+present), wall box present, motion matches MuJoCo viewer run.
+*Verifies REQ-VIZ-002.*
+
+**TC-VIZ-003 — Patch module behavior** (L1) `meshcat_patch` on: pristine bundle
+→ patches; patched bundle → silent no-op; unknown bundle → loud warning, no
+modification. Legacy script imports it (inspection).
+*Verifies REQ-VIZ-004.*
+
+**TC-VIZ-004 — Headless** (L3) `--viewer none` completes with no display server
+access (unset DISPLAY in test env). *Verifies REQ-VIZ-003.*
+
+**TC-EXP-001 — LogSchema contract** (L1) Runner output contains exactly the
+documented channels with documented shapes; `Task.metrics` and `Recorder`
+consume the same object without adaptation. *Verifies REQ-EXP-001.*
+
+**TC-REC-001 — Recorder round-trip** (L1) Record a short run; reload
+`timeseries.npz` + `config.json`; arrays equal in-memory log; config
+reconstructs dataclasses; `data/runs/` gitignored (inspection).
+*Verifies REQ-REC-001/002.*
+
+**TC-ANA-001 — Sweep integrity** (L3, Phase 7) 2×2 YAML grid runs headless in
+parallel; aggregate contains 4 rows with correct config columns; a seeded rerun
+reproduces metrics. *Verifies REQ-ANA-001, REQ-NFR-003.*
+
+**TC-ANA-002 — Payload estimation sanity** (L3, Phase 8) Known 2 kg payload:
+estimate within 5% after documented excitation trajectory; error reported vs
+ground truth. *Verifies REQ-ANA-003.*
+
+**TC-LEG-001 — Legacy untouched** (L3/D) `echo "" | python controllers/impedance_6dof.py`
+exits 0, "Simulation ended" printed; meshcat shows full arm (spot demo per
+release). *Verifies REQ-NFR-006.*
+
+## 3. Traceability Matrix (requirement → design → tests → phase)
+
+| Requirement | Design | Test cases | Phase |
+|---|---|---|---|
+| REQ-MDL-001 | §3.1 | TC-MDL-001 | 1 |
+| REQ-MDL-002 | §3.1, DD-1 | TC-MDL-001, TC-CE-001..003 | 1 |
+| REQ-MDL-003 | §3.1/3.3, DD-3 | TC-MDL-002, TC-CE-001..003 | 1 |
+| REQ-MDL-004 | §3.1 | TC-MDL-003, TC-CE-004 | 1 |
+| REQ-MDL-005 | §3.2, DD-9 | TC-MDL-004, TC-VAL-003 | 1 / 4 |
+| REQ-SIM-001 | §3.3 | TC-SIM-001/002, TC-CTL-006 | 1 |
+| REQ-SIM-002 | §3.3, DD-3 | TC-SIM-002 | 1 |
+| REQ-SIM-003 | §3.3 | TC-SIM-003 | 1 |
+| REQ-SIM-004 | §3.3 | TC-SYS-003 | 4 |
+| REQ-SIM-005 | §3.3 | TC-SIM-004, TC-SYS-002 | 1–2 |
+| REQ-SIM-006 | DD-2, §3.3 | TC-SIM-001, TC-CTL-001 | 1–2 |
+| REQ-SIM-007 | §3.8 | TC-SIM-005 | 2 |
+| REQ-CTL-001 | DD-2, §3.5 | TC-CTL-001 | 2 |
+| REQ-CTL-002 | §3.4 | TC-CTL-002 | 2 |
+| REQ-CTL-003 | §3.5 | TC-CTL-003/004, TC-CTL-001 | 2 |
+| REQ-CTL-004 | §3.5/3.8 | TC-CTL-006 | 2 |
+| REQ-CTL-005 | §3.5 | TC-CTL-005 | 2 |
+| REQ-CTL-006 | §3.5 | TC-CTL-008 | 6 |
+| REQ-CTL-007 | DD-6 | TC-CTL-007 | 2 |
+| REQ-TSK-001 | DD-8, §3.6 | TC-SIM-001, inspection | 1–2 |
+| REQ-TSK-002 | §3.6 | TC-SYS-001/002 | 2 |
+| REQ-TSK-003 | §3.6 | TC-SYS-003, TC-VAL-001 | 4 |
+| REQ-TSK-004 | §3.6 | TC-SYS-004 | 4 |
+| REQ-VIZ-001 | §3.7, DD-7 | TC-VIZ-001 | 3 |
+| REQ-VIZ-002 | §3.7, DD-7 | TC-VIZ-002 | 3 |
+| REQ-VIZ-003 | §3.7 | TC-VIZ-004 | 3 |
+| REQ-VIZ-004 | §3.7 | TC-VIZ-003 | 3 |
+| REQ-EXP-001 | §3.8, DD-5 | TC-EXP-001, TC-SYS-001 | 2 |
+| REQ-EXP-002 | experiments/_common.py | inspection | 2 |
+| REQ-EXP-003 | §3.8 | demo w/ TC-VIZ-001 | 2–4 |
+| REQ-REC-001 | §3.9, §2.3 | TC-REC-001 | 5 |
+| REQ-REC-002 | .gitignore | TC-REC-001 (I) | 5 |
+| REQ-ANA-001 | §3.9, DD-6 | TC-ANA-001 | 7 |
+| REQ-ANA-002 | §3.9 | TC-ANA-001 variant | 7 |
+| REQ-ANA-003 | §3.9 | TC-ANA-002 | 8 |
+| REQ-NFR-001 | DD-1/3 | TC-CE-001..004 | 1 |
+| REQ-NFR-002 | — | TC-VAL-002 | 2 |
+| REQ-NFR-003 | §3.8 | TC-SIM-005, TC-ANA-001 | 2 / 7 |
+| REQ-NFR-004 | requirements.txt | inspection | 0 |
+| REQ-NFR-005 | tests/ | the suite itself + inspection | all |
+| REQ-NFR-006 | untouched legacy | TC-LEG-001, TC-CTL-004 | all |
+| REQ-NFR-007 | DD-4/5/6 | inspection at Phase 6 | 6 |
+
+**Coverage check**: every REQ row has ≥1 verification activity; every TC verifies
+≥1 REQ. Update this table in the same commit as any requirement or test change.
+
+## 4. Regression & Release Discipline
+
+- `./.venv/bin/pytest tests/ -q` green before every commit (Phase ≥1); a phase
+  exits only with its L3/L4 items done and findings.md updated.
+- Golden baselines (TC-SYS-001/004) are recorded once, committed as fixtures,
+  and only changed with a justification note in the commit message.
+- Demonstrations (TC-VIZ-001/002, TC-LEG-001) re-run at each phase exit that
+  touches their area; observations noted in findings.md.
+- Test seeds recorded inside the tests; never time- or entropy-derived.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pin==4.1.0
+example-robot-data-loaders==5.0.0
+numpy==2.5.1
+matplotlib==3.11.0
+meshcat==0.3.2


### PR DESCRIPTION
Verified controllers/impedance_6dof.py runs unchanged against pin 4.1.0 (the old RobotWrapper convenience methods and pin.aba/integrate/rpy API are all still present). example-robot-data 4.4+ split the Python loader out into example-robot-data-loaders, so that's now the direct dependency.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
